### PR TITLE
Add optimisation_all_metrics and incremental_save options to Pipeline

### DIFF
--- a/recpack/pipelines/pipeline.py
+++ b/recpack/pipelines/pipeline.py
@@ -6,6 +6,7 @@
 #   Robin Verachtert
 
 from collections import defaultdict
+import json
 import logging
 import os
 from typing import Tuple, Union, Dict, List, Any, Optional, Callable
@@ -102,7 +103,22 @@ class Pipeline(object):
     :type post_processor: Postprocessor
     :param remove_history: Boolean to configure if the recommendations can include items that were previously interacted with.
     :type remove_history: Boolean
+    :param optimisation_all_metrics: If True, all configured metrics are calculated for every
+        validation run during hyperparameter optimisation, in addition to the optimisation metric.
+        These extra values are stored in the optimisation results so they can be inspected afterwards.
+        The optimisation metric is still the only metric used to select the best hyperparameters.
+        Defaults to False.
+    :type optimisation_all_metrics: bool
+    :param incremental_save: If True, intermediate results are appended to disk as soon as they
+        become available, rather than only at the end. Each validation trial result is appended
+        to ``optimisation_results.jsonl`` and each final test metric is appended to
+        ``results.jsonl`` in the ``results_directory``. This protects against losing all results
+        if the pipeline terminates before completion. Defaults to False.
+    :type incremental_save: bool
     """
+
+    OPTIMISATION_RESULTS_FILE = "optimisation_results.jsonl"
+    RESULTS_FILE = "results.jsonl"
 
     def __init__(
         self,
@@ -116,6 +132,8 @@ class Pipeline(object):
         optimisation_metric_entry: Union[OptimisationMetricEntry, None],
         post_processor: Postprocessor,
         remove_history: bool,
+        optimisation_all_metrics: bool = False,
+        incremental_save: bool = False,
     ):
         self.results_directory = results_directory
         self.algorithm_entries = algorithm_entries
@@ -127,10 +145,29 @@ class Pipeline(object):
         self.optimisation_metric_entry = optimisation_metric_entry
         self.post_processor = post_processor
         self.remove_history = remove_history
+        self.optimisation_all_metrics = optimisation_all_metrics
+        self.incremental_save = incremental_save
 
         self._metric_acc = MetricAccumulator()
         # Hyperparameter optimisation results are accumulated
         self._optimisation_results = []
+
+        if self.incremental_save:
+            os.makedirs(self.results_directory, exist_ok=True)
+
+    def _append_jsonl(self, filename: str, record: Dict[str, Any]) -> None:
+        """Append a single JSON record as one line to ``{results_directory}/{filename}``.
+
+        The file is opened, written, flushed and closed for every record so that
+        partial results survive an unexpected pipeline termination.
+        """
+        path = os.path.join(self.results_directory, filename)
+        try:
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, default=str) + "\n")
+                f.flush()
+        except OSError as e:
+            logger.warning(f"Could not append intermediate result to {path}: {e}")
 
     def run(self):
         """Runs the pipeline."""
@@ -159,6 +196,19 @@ class Pipeline(object):
                     metric = metric_cls()
                 metric.calculate(self.test_data_out.binary_values, X_pred)
                 self._metric_acc.add(metric, algorithm.identifier, metric.name)
+                logger.info(
+                    f"Test metric {metric.name} = {metric.value} for {algorithm.identifier}"
+                )
+                if self.incremental_save:
+                    self._append_jsonl(
+                        self.RESULTS_FILE,
+                        {
+                            "algorithm": algorithm_entry.name,
+                            "identifier": algorithm.identifier,
+                            "metric": metric.name,
+                            "value": metric.value,
+                        },
+                    )
 
     def _train(self, algorithm: Algorithm, training_data: InteractionMatrix) -> Algorithm:
         if isinstance(algorithm, TorchMLAlgorithm):
@@ -202,6 +252,42 @@ class Pipeline(object):
                 "params": {**args, **algorithm_entry.params},
                 optimisation_metric.name: optimisation_metric.value,
             }
+
+            # Optionally compute all configured metrics on the validation data
+            # so that all metric values are available for inspection in the
+            # optimisation results, in addition to the optimisation metric.
+            if self.optimisation_all_metrics:
+                for metric_entry in self.metric_entries:
+                    metric_cls = METRIC_REGISTRY.get(metric_entry.name)
+                    if metric_entry.K is not None:
+                        metric = metric_cls(K=metric_entry.K)
+                    else:
+                        metric = metric_cls()
+                    try:
+                        metric.calculate(validation_data_out.binary_values, X_pred_val)
+                    except Exception as e:
+                        logger.warning(
+                            f"Could not calculate metric {metric.name} on validation data: {e}"
+                        )
+                        continue
+                    # Avoid overwriting the optimisation metric entry.
+                    if metric.name not in result:
+                        result[metric.name] = metric.value
+
+            # Log the validation metric for this trial so progress is visible in
+            # the log even if the pipeline is terminated before the end.
+            logger.info(
+                f"Validation {optimisation_metric.name} = {optimisation_metric.value} "
+                f"for {algorithm.identifier}"
+            )
+
+            # Persist this single trial result to disk immediately so that
+            # hyperparameter optimisation progress is not lost if the pipeline
+            # terminates before completion.
+            if self.incremental_save:
+                # Strip non-serialisable / hyperopt-internal keys.
+                serialisable = {k: v for k, v in result.items() if k != "status"}
+                self._append_jsonl(self.OPTIMISATION_RESULTS_FILE, serialisable)
 
             # Hyperopt always minimises, so to maximize a metric we just turn it negative.
             if not self.optimisation_metric_entry.minimise:

--- a/recpack/pipelines/pipeline_builder.py
+++ b/recpack/pipelines/pipeline_builder.py
@@ -64,6 +64,8 @@ class PipelineBuilder(object):
         self.post_processor = Postprocessor()
 
         self.remove_history = True
+        self.optimisation_all_metrics = False
+        self.incremental_save = False
 
         self.results_directory = f"{self.base_path}/{self.folder_name}"
 
@@ -181,6 +183,35 @@ class PipelineBuilder(object):
             raise ValueError(f"metric {metric} could not be resolved.")
 
         self.optimisation_metric = OptimisationMetricEntry(metric, K, minimise)
+
+    def set_incremental_save(self, value: bool = True) -> None:
+        """Toggle whether intermediate results are appended to disk during the run.
+
+        When enabled, validation trial results are appended to
+        ``optimisation_results.jsonl`` and final test metrics are appended to
+        ``results.jsonl`` in the configured ``results_directory``. This protects
+        against losing partial results if the pipeline terminates before
+        completion.
+
+        :param value: If True, save intermediate results incrementally. Defaults to True.
+        :type value: bool
+        """
+        self.incremental_save = value
+
+    def set_optimisation_all_metrics(self, value: bool = True) -> None:
+        """Toggle whether all configured metrics are calculated for every
+        validation run during hyperparameter optimisation.
+
+        When enabled, the optimisation results will contain a column for each
+        configured metric, in addition to the optimisation metric. The selection
+        of the best hyperparameter combination is unaffected: it still uses the
+        optimisation metric only.
+
+        :param value: If True, calculate all metrics for validation runs.
+            Defaults to True.
+        :type value: bool
+        """
+        self.optimisation_all_metrics = value
 
     def set_full_training_data(self, train_data: InteractionMatrix):
         """Set the full_training dataset.
@@ -330,4 +361,6 @@ class PipelineBuilder(object):
             self.optimisation_metric if hasattr(self, "optimisation_metric") else None,
             self.post_processor,
             self.remove_history,
+            self.optimisation_all_metrics,
+            self.incremental_save,
         )

--- a/recpack/tests/test_pipelines/test_pipeline.py
+++ b/recpack/tests/test_pipelines/test_pipeline.py
@@ -5,6 +5,9 @@
 #   Lien Michiels
 #   Robin Verachtert
 
+import json
+import logging
+import os
 import time
 from unittest.mock import MagicMock, patch, call
 
@@ -87,6 +90,37 @@ def test_pipeline_optimisation_gridsearch(
     assert metrics.shape[0] == len(pipeline.algorithm_entries)
     assert metrics.shape[1] == len(pipeline.metric_entries)
     assert pipeline.optimisation_results.shape[0] == gridsize
+
+
+def test_pipeline_optimisation_results_default_single_metric(pipeline_builder_optimisation):
+    """By default only the optimisation metric is recorded for validation runs."""
+    pipeline = pipeline_builder_optimisation.build()
+    pipeline.run()
+
+    opt_results = pipeline.optimisation_results
+    # Optimisation metric is CalibratedRecallK_2; CalibratedRecallK_3 is also configured
+    # but should NOT appear in the optimisation results when the flag is off.
+    assert "CalibratedRecallK_2" in opt_results.columns
+    assert "CalibratedRecallK_3" not in opt_results.columns
+
+
+def test_pipeline_optimisation_results_all_metrics(pipeline_builder_optimisation):
+    """When optimisation_all_metrics is enabled, every configured metric is
+    calculated and stored for each validation run."""
+    pipeline_builder_optimisation.set_optimisation_all_metrics(True)
+    pipeline = pipeline_builder_optimisation.build()
+    pipeline.run()
+
+    opt_results = pipeline.optimisation_results
+    assert "CalibratedRecallK_2" in opt_results.columns
+    assert "CalibratedRecallK_3" in opt_results.columns
+    # All values should be populated (no NaN)
+    assert opt_results["CalibratedRecallK_2"].notna().all()
+    assert opt_results["CalibratedRecallK_3"].notna().all()
+    # Best-parameter selection still uses only the optimisation metric, so the
+    # final test-set evaluation should still produce a regular metrics table.
+    metrics = pipeline.get_metrics()
+    assert metrics.shape[0] == len(pipeline.algorithm_entries)
 
 
 def test_pipeline_with_filters_applied(pipeline_builder):
@@ -209,3 +243,98 @@ def test_pipeline_optimisation_results_output(pipeline_builder_optimisation_no_a
 
     # EASE optimial hyperparameter asserts
     assert "l2" in pipe.optimisation_results["params"].iloc[-1]
+
+
+def test_pipeline_logs_validation_metric(pipeline_builder_optimisation, caplog):
+    """The validation metric should be logged for every trial so progress is
+    visible even if the pipeline is terminated before it completes."""
+    pipeline = pipeline_builder_optimisation.build()
+    with caplog.at_level(logging.INFO, logger="recpack"):
+        pipeline.run()
+
+    validation_log_messages = [
+        rec.message for rec in caplog.records if "Validation" in rec.message
+    ]
+    # 3 ItemKNN trials + 2 EASE trials = 5 validation log lines
+    assert len(validation_log_messages) == 5
+    for msg in validation_log_messages:
+        assert "CalibratedRecallK_2" in msg
+
+
+def test_pipeline_logs_test_metric(pipeline_builder, caplog):
+    """Final test metrics should also be logged so they appear in the run log."""
+    pipeline = pipeline_builder.build()
+    with caplog.at_level(logging.INFO, logger="recpack"):
+        pipeline.run()
+
+    test_log_messages = [
+        rec.message for rec in caplog.records if "Test metric" in rec.message
+    ]
+    # 2 algorithms x 2 metrics = 4 test metric log lines
+    assert len(test_log_messages) == 4
+
+
+def test_pipeline_incremental_save_writes_test_metrics(pipeline_builder, tmp_path):
+    """When incremental_save is enabled, each test metric should be appended
+    to results.jsonl as soon as it is computed."""
+    pipeline_builder.base_path = str(tmp_path)
+    pipeline_builder.results_directory = f"{pipeline_builder.base_path}/{pipeline_builder.folder_name}"
+    pipeline_builder.set_incremental_save(True)
+
+    pipeline = pipeline_builder.build()
+    pipeline.run()
+
+    results_file = os.path.join(pipeline.results_directory, "results.jsonl")
+    assert os.path.exists(results_file)
+
+    with open(results_file, "r", encoding="utf-8") as f:
+        lines = [json.loads(l) for l in f if l.strip()]
+
+    # 2 algorithms x 2 metrics = 4 records
+    assert len(lines) == 4
+    for record in lines:
+        assert "algorithm" in record
+        assert "identifier" in record
+        assert "metric" in record
+        assert "value" in record
+
+
+def test_pipeline_incremental_save_writes_optimisation_results(pipeline_builder_optimisation, tmp_path):
+    """When incremental_save is enabled, each validation trial should be
+    appended to optimisation_results.jsonl as it runs."""
+    pipeline_builder_optimisation.base_path = str(tmp_path)
+    pipeline_builder_optimisation.results_directory = (
+        f"{pipeline_builder_optimisation.base_path}/{pipeline_builder_optimisation.folder_name}"
+    )
+    pipeline_builder_optimisation.set_incremental_save(True)
+
+    pipeline = pipeline_builder_optimisation.build()
+    pipeline.run()
+
+    opt_file = os.path.join(pipeline.results_directory, "optimisation_results.jsonl")
+    assert os.path.exists(opt_file)
+
+    with open(opt_file, "r", encoding="utf-8") as f:
+        lines = [json.loads(l) for l in f if l.strip()]
+
+    # 3 ItemKNN trials + 2 EASE trials = 5 records
+    assert len(lines) == 5
+    for record in lines:
+        assert "algorithm" in record
+        assert "identifier" in record
+        assert "params" in record
+        assert "loss" in record
+
+
+def test_pipeline_incremental_save_disabled_writes_nothing(pipeline_builder, tmp_path):
+    """When incremental_save is disabled (default), no jsonl files should be created."""
+    pipeline_builder.base_path = str(tmp_path)
+    pipeline_builder.results_directory = f"{pipeline_builder.base_path}/{pipeline_builder.folder_name}"
+
+    pipeline = pipeline_builder.build()
+    pipeline.run()
+
+    # Files should not exist; results_directory may not even have been created.
+    if os.path.isdir(pipeline.results_directory):
+        assert not os.path.exists(os.path.join(pipeline.results_directory, "results.jsonl"))
+        assert not os.path.exists(os.path.join(pipeline.results_directory, "optimisation_results.jsonl"))


### PR DESCRIPTION
## Summary

This PR adds two new optional Pipeline features:

* `optimisation_all_metrics`: calculates and stores all configured metrics for every validation trial, while still using only the selected optimisation metric to choose the best parameters.
* `incremental_save`: saves optimisation and evaluation results incrementally in JSONL files, preventing completed results from being lost if a pipeline run is interrupted.

Both options are disabled by default to preserve existing behaviour.
