### PR TITLE
Save intermediate results during pipeline runs

### DIFF
--- a/recpack/pipelines/pipeline.py
+++ b/recpack/pipelines/pipeline.py
@@ -6,6 +6,7 @@
 #   Robin Verachtert
 
 from collections import defaultdict
+import json
 import logging
 import os
 from typing import Tuple, Union, Dict, List, Any, Optional, Callable
@@ -102,7 +103,14 @@ class Pipeline(object):
     :type post_processor: Postprocessor
     :param remove_history: Boolean to configure if the recommendations can include items that were previously interacted with.
     :type remove_history: Boolean
+    :param incremental_save: If True, results are appended to JSONL files in the
+        results directory as soon as they are obtained, so partial results
+        survive an unexpected termination. Defaults to False.
+    :type incremental_save: bool, optional
     """
+
+    OPTIMISATION_RESULTS_FILE = "optimisation_results.jsonl"
+    RESULTS_FILE = "results.jsonl"
 
     def __init__(
         self,
@@ -116,6 +124,7 @@ class Pipeline(object):
         optimisation_metric_entry: Union[OptimisationMetricEntry, None],
         post_processor: Postprocessor,
         remove_history: bool,
+        incremental_save: bool = False,
     ):
         self.results_directory = results_directory
         self.algorithm_entries = algorithm_entries
@@ -127,10 +136,27 @@ class Pipeline(object):
         self.optimisation_metric_entry = optimisation_metric_entry
         self.post_processor = post_processor
         self.remove_history = remove_history
+        self.incremental_save = incremental_save
+
+        if self.incremental_save:
+            os.makedirs(self.results_directory, exist_ok=True)
 
         self._metric_acc = MetricAccumulator()
         # Hyperparameter optimisation results are accumulated
         self._optimisation_results = []
+
+    def _append_jsonl(self, filename: str, record: Dict[str, Any]) -> None:
+        """Append a single record as a JSON line to a file in the results directory.
+
+        Failures to write are logged, not raised, so a transient file-system
+        issue cannot break the run.
+        """
+        try:
+            with open(os.path.join(self.results_directory, filename), "a") as f:
+                f.write(json.dumps(record, default=str) + "\n")
+                f.flush()
+        except OSError as e:
+            logger.warning(f"Could not append result to {filename}: {e}")
 
     def run(self):
         """Runs the pipeline."""
@@ -159,6 +185,19 @@ class Pipeline(object):
                     metric = metric_cls()
                 metric.calculate(self.test_data_out.binary_values, X_pred)
                 self._metric_acc.add(metric, algorithm.identifier, metric.name)
+
+                logger.info(f"Test metric {metric.name} = {metric.value} for {algorithm.identifier}")
+
+                if self.incremental_save:
+                    self._append_jsonl(
+                        self.RESULTS_FILE,
+                        {
+                            "algorithm": algorithm_entry.name,
+                            "identifier": algorithm.identifier,
+                            "metric": metric.name,
+                            "value": metric.value,
+                        },
+                    )
 
     def _train(self, algorithm: Algorithm, training_data: InteractionMatrix) -> Algorithm:
         if isinstance(algorithm, TorchMLAlgorithm):
@@ -202,6 +241,14 @@ class Pipeline(object):
                 "params": {**args, **algorithm_entry.params},
                 optimisation_metric.name: optimisation_metric.value,
             }
+
+            logger.info(
+                f"Validation {optimisation_metric.name} = {optimisation_metric.value} for {algorithm.identifier}"
+            )
+
+            if self.incremental_save:
+                record = {k: v for k, v in result.items() if k != "status"}
+                self._append_jsonl(self.OPTIMISATION_RESULTS_FILE, record)
 
             # Hyperopt always minimises, so to maximize a metric we just turn it negative.
             if not self.optimisation_metric_entry.minimise:

--- a/recpack/pipelines/pipeline_builder.py
+++ b/recpack/pipelines/pipeline_builder.py
@@ -64,6 +64,7 @@ class PipelineBuilder(object):
         self.post_processor = Postprocessor()
 
         self.remove_history = True
+        self.incremental_save = False
 
         self.results_directory = f"{self.base_path}/{self.folder_name}"
 
@@ -230,6 +231,18 @@ class PipelineBuilder(object):
 
         self.test_data = test_data
 
+    def set_incremental_save(self, value: bool = True) -> None:
+        """Enable or disable incremental saving of results.
+
+        When enabled, validation and test metric results are appended to
+        JSONL files in the results directory as soon as they are obtained,
+        so partial results survive an unexpected termination of the pipeline.
+
+        :param value: True to enable incremental saving, defaults to True
+        :type value: bool, optional
+        """
+        self.incremental_save = value
+
     def set_data_from_scenario(self, scenario: Scenario):
         """Set the train, validation and test data based by
         extracting them from the scenario."""
@@ -330,4 +343,5 @@ class PipelineBuilder(object):
             self.optimisation_metric if hasattr(self, "optimisation_metric") else None,
             self.post_processor,
             self.remove_history,
+            self.incremental_save,
         )

--- a/recpack/tests/test_pipelines/test_pipeline.py
+++ b/recpack/tests/test_pipelines/test_pipeline.py
@@ -5,6 +5,9 @@
 #   Lien Michiels
 #   Robin Verachtert
 
+import json
+import logging
+import os
 import time
 from unittest.mock import MagicMock, patch, call
 
@@ -209,3 +212,81 @@ def test_pipeline_optimisation_results_output(pipeline_builder_optimisation_no_a
 
     # EASE optimial hyperparameter asserts
     assert "l2" in pipe.optimisation_results["params"].iloc[-1]
+
+
+def test_pipeline_logs_validation_metric(pipeline_builder_optimisation, caplog):
+    pipeline = pipeline_builder_optimisation.build()
+
+    with caplog.at_level(logging.INFO, logger="recpack"):
+        pipeline.run()
+
+    validation_logs = [
+        r for r in caplog.records if r.levelno == logging.INFO and r.getMessage().startswith("Validation ")
+    ]
+    # One log line per validation trial: 3 for ItemKNN, 2 for EASE
+    assert len(validation_logs) == 5
+
+
+def test_pipeline_logs_test_metric(pipeline_builder, caplog):
+    pipeline = pipeline_builder.build()
+
+    with caplog.at_level(logging.INFO, logger="recpack"):
+        pipeline.run()
+
+    test_metric_logs = [
+        r for r in caplog.records if r.levelno == logging.INFO and r.getMessage().startswith("Test metric ")
+    ]
+    # One log line per (algorithm, metric) pair
+    assert len(test_metric_logs) == len(pipeline.algorithm_entries) * len(pipeline.metric_entries)
+
+
+def test_pipeline_incremental_save_writes_test_metrics(pipeline_builder, tmp_path):
+    pipeline_builder.results_directory = str(tmp_path / "results")
+    pipeline_builder.set_incremental_save(True)
+    pipeline = pipeline_builder.build()
+
+    pipeline.run()
+
+    results_file = os.path.join(pipeline.results_directory, pipeline.RESULTS_FILE)
+    assert os.path.exists(results_file)
+
+    with open(results_file) as f:
+        records = [json.loads(line) for line in f]
+
+    assert len(records) == len(pipeline.algorithm_entries) * len(pipeline.metric_entries)
+    for record in records:
+        assert set(record.keys()) == {"algorithm", "identifier", "metric", "value"}
+        assert isinstance(record["value"], float)
+
+
+def test_pipeline_incremental_save_writes_optimisation_results(pipeline_builder_optimisation, tmp_path):
+    pipeline_builder_optimisation.results_directory = str(tmp_path / "results")
+    pipeline_builder_optimisation.set_incremental_save(True)
+    pipeline = pipeline_builder_optimisation.build()
+
+    pipeline.run()
+
+    optimisation_file = os.path.join(pipeline.results_directory, pipeline.OPTIMISATION_RESULTS_FILE)
+    assert os.path.exists(optimisation_file)
+
+    with open(optimisation_file) as f:
+        records = [json.loads(line) for line in f]
+
+    # One record per validation trial: 3 for ItemKNN, 2 for EASE
+    assert len(records) == 5
+    for record in records:
+        assert "status" not in record
+        assert "loss" in record
+        assert "algorithm" in record
+        assert "identifier" in record
+        assert "params" in record
+
+
+def test_pipeline_incremental_save_disabled_writes_nothing(pipeline_builder_optimisation, tmp_path):
+    pipeline_builder_optimisation.results_directory = str(tmp_path / "results")
+    pipeline = pipeline_builder_optimisation.build()
+
+    pipeline.run()
+
+    assert not os.path.exists(os.path.join(pipeline.results_directory, pipeline.RESULTS_FILE))
+    assert not os.path.exists(os.path.join(pipeline.results_directory, pipeline.OPTIMISATION_RESULTS_FILE))


### PR DESCRIPTION
## Description
Currently recpack only outputs metric results at the end of an experiment
pipeline; if a run is interrupted, all results are lost.

This PR implements both parts of the "Saving intermediate results" issue:

- **Easy**: every validation and test metric is now logged at INFO level on
  the `recpack` logger, e.g. `Validation CalibratedRecallK_10 = 0.421 for ItemKNN(K=100)`.
- **Advanced**: a new opt-in `incremental_save` flag
  (`PipelineBuilder.set_incremental_save(True)`) appends each result as one
  JSON line to `optimisation_results.jsonl` / `results.jsonl` in the results
  directory as soon as it is obtained, so partial results survive a crash.
  Each line is independently parseable (`pd.read_json(..., lines=True)`).

## Backward compatibility
- `incremental_save` defaults to `False`: no new files, no extra I/O.
- Logging follows the existing pattern (silent unless the app configures logging).
- The existing `save_metrics()` JSON output is unchanged.

## Tests
5 new tests in `test_pipeline.py` cover the logging and incremental-save
behaviour; all pre-existing pipeline tests pass (58 passed).