### PR TITLE
Make time information accessible to algorithms

### DIFF
--- a/recpack/algorithms/__init__.py
+++ b/recpack/algorithms/__init__.py
@@ -46,6 +46,7 @@ or for comparison in experiments.
 
     Popularity
     Random
+    TimeAwarePopularity
 
 Item Similarity Algorithms
 ----------------------------
@@ -238,12 +239,13 @@ Use these to simplify certain tasks (such as batching) when creating a new algor
 
 from recpack.algorithms.base import (
     Algorithm,
+    TimeAwareAlgorithm,
     TopKItemSimilarityMatrixAlgorithm,
     TorchMLAlgorithm,
     ItemSimilarityMatrixAlgorithm,
     FactorizationAlgorithm,
 )
-from recpack.algorithms.baseline import Popularity, Random
+from recpack.algorithms.baseline import Popularity, Random, TimeAwarePopularity
 from recpack.algorithms.factorization import (
     NMF,
     SVD,

--- a/recpack/algorithms/base.py
+++ b/recpack/algorithms/base.py
@@ -217,6 +217,99 @@ class Algorithm(BaseEstimator):
         return X_pred
 
 
+class TimeAwareAlgorithm(Algorithm):
+    """Base class for algorithms that use timestamp information.
+
+    Instead of a binary csr matrix, the :meth:`_fit` and :meth:`_predict`
+    methods of child classes receive the full
+    :class:`recpack.matrix.InteractionMatrix`,
+    such that per interaction timestamps can be used
+    during training and prediction.
+
+    Input is validated instead of converted:
+    a TypeError is raised when the input is not an InteractionMatrix,
+    and a ValueError is raised when the InteractionMatrix
+    has no timestamp information.
+
+    Usually a new algorithm will have to
+    implement just the :meth:`_fit` and :meth:`_predict` methods.
+    """
+
+    def _fit(self, X: InteractionMatrix):
+        """Stub implementation for fitting an algorithm.
+
+        Will be called by the :meth:`fit` wrapper.
+        Child classes should implement this function.
+
+        :param X: User-item interaction matrix, with timestamps,
+            to fit the model to.
+        :type X: InteractionMatrix
+        :raises NotImplementedError: Implement this method in the child class
+        """
+        raise NotImplementedError("Please implement _fit")
+
+    def _predict(self, X: InteractionMatrix) -> csr_matrix:
+        """Stub for predicting scores to users
+
+        Will be called by the :meth:`predict` wrapper.
+        Child classes should implement this function.
+
+        :param X: User-item interaction matrix, with timestamps,
+            used as input to predict.
+        :type X: InteractionMatrix
+        :raises NotImplementedError: Implement this method in the child class
+        :return: Predictions made for all active users in X
+        :rtype: csr_matrix
+        """
+        raise NotImplementedError("Please implement _predict")
+
+    def _transform_fit_input(self, X: Matrix) -> InteractionMatrix:
+        """Check the training data is an InteractionMatrix with timestamps,
+        and pass it through unchanged.
+
+        :param X: User-item interaction matrix to fit the model to
+        :type X: Matrix
+        :return: The user-item interaction matrix, with timestamp information.
+        :rtype: InteractionMatrix
+        """
+        self._assert_is_interaction_matrix(X)
+        self._assert_has_timestamps(X)
+        return X
+
+    def _transform_predict_input(self, X: Matrix) -> InteractionMatrix:
+        """Check the input of predict is an InteractionMatrix with timestamps,
+        and pass it through unchanged.
+
+        :param X: User-item interaction matrix used as input to predict
+        :type X: Matrix
+        :return: The user-item interaction matrix, with timestamp information.
+        :rtype: InteractionMatrix
+        """
+        self._assert_is_interaction_matrix(X)
+        self._assert_has_timestamps(X)
+        return X
+
+    def _check_prediction(self, X_pred: csr_matrix, X: InteractionMatrix) -> None:
+        """Checks that the predictions matches expectations
+
+        Checks implemented:
+
+        - Check that all users with history got at least 1 recommendation
+
+        For failing checks a warning is printed.
+
+        :param X_pred: Predictions made for all active users in X
+        :type X_pred: csr_matrix
+        :param X: User-item interaction matrix used as input to predict
+        :type X: InteractionMatrix
+        """
+        users = X.active_users
+        predicted_users = set(X_pred.nonzero()[0])
+        missing = users.difference(predicted_users)
+        if len(missing) > 0:
+            warnings.warn(f"{self.name} failed to recommend any items " f"for {len(missing)} users")
+
+
 class ItemSimilarityMatrixAlgorithm(Algorithm):
     """Base algorithm for algorithms that fit an item to item similarity model
 

--- a/recpack/algorithms/baseline.py
+++ b/recpack/algorithms/baseline.py
@@ -10,7 +10,8 @@ import warnings
 import numpy as np
 from scipy.sparse import csr_matrix, lil_matrix
 
-from recpack.algorithms.base import Algorithm
+from recpack.algorithms.base import Algorithm, TimeAwareAlgorithm
+from recpack.matrix import InteractionMatrix
 from recpack.util import get_top_K_values
 
 
@@ -112,6 +113,76 @@ class Popularity(Algorithm):
         """For each user predict the K most popular items"""
 
         users = list(set(X.nonzero()[0]))
+
+        X_pred = lil_matrix(X.shape)
+        X_pred[users] = self.sorted_scores_
+
+        return X_pred.tocsr()
+
+
+class TimeAwarePopularity(TimeAwareAlgorithm):
+    """Baseline algorithm recommending the most popular items,
+    where each interaction is weighted by its recency.
+
+    During training each interaction is given an exponentially decayed weight
+
+    .. math::
+
+        w(t) = e^{- \\frac{t_{max} - t}{decay}}
+
+    where :math:`t_{max}` is the maximal timestamp in the training data.
+    The score of an item is the sum of the weights of its interactions,
+    normalized by the maximal score over items,
+    so all scores fall in the interval [0, 1].
+
+    If ``decay`` is None or not strictly positive,
+    every interaction gets weight 1,
+    which makes the ranking identical to the plain
+    :class:`Popularity` algorithm.
+
+    :param K: How many items to recommend when predicting, defaults to 200
+    :type K: int, optional
+    :param decay: Time scale of the exponential decay, in the same unit
+        as the timestamps in the InteractionMatrix
+        (e.g. ``decay=86400.`` is a one day time scale for epoch timestamps in seconds).
+        If None, no decay is applied. Defaults to None.
+    :type decay: float, optional
+    """
+
+    def __init__(self, K: int = 200, decay: Optional[float] = None):
+        super().__init__()
+        self.K = K
+        self.decay = decay
+
+    def _fit(self, X: InteractionMatrix) -> "TimeAwarePopularity":
+        timestamps = X.timestamps
+
+        if self.decay is not None and self.decay > 0:
+            weights = np.exp(-(timestamps.max() - timestamps) / self.decay)
+            item_scores = weights.groupby(level=1).sum()
+        else:
+            # Weight 1 per interaction, equivalent to plain Popularity counts.
+            item_scores = timestamps.groupby(level=1).count()
+
+        num_items = X.shape[1]
+        scores = np.zeros(num_items)
+        scores[item_scores.index.values] = item_scores.values
+        scores = scores / scores.max()
+
+        if num_items < self.K:
+            warnings.warn("K is larger than the number of items.", UserWarning)
+
+        K = min(self.K, num_items)
+        ind = np.argpartition(scores, -K)[-K:]
+        a = np.zeros(num_items)
+        a[ind] = scores[ind]
+        self.sorted_scores_ = a
+        return self
+
+    def _predict(self, X: InteractionMatrix) -> csr_matrix:
+        """For each active user predict the K most popular scores"""
+
+        users = list(X.active_users)
 
         X_pred = lil_matrix(X.shape)
         X_pred[users] = self.sorted_scores_

--- a/recpack/tests/test_algorithms/test_algorithms_base.py
+++ b/recpack/tests/test_algorithms/test_algorithms_base.py
@@ -13,7 +13,8 @@ import scipy.sparse
 from unittest.mock import MagicMock
 
 
-from recpack.algorithms.base import Algorithm
+from recpack.algorithms.base import Algorithm, TimeAwareAlgorithm
+from recpack.matrix import InteractionMatrix
 from recpack.algorithms import (
     ItemKNN,
     MultVAE,
@@ -167,3 +168,45 @@ def test_sampled_validation(algo_class, larger_mat):
         val_out, X_pred = c.args
         assert len(set(val_out.nonzero()[0])) == N_SAMPLES
         assert len(set(X_pred.nonzero()[0])) == N_SAMPLES
+
+
+class _DummyTimeAware(TimeAwareAlgorithm):
+    """Minimal TimeAwareAlgorithm used to test the wrapper behaviour."""
+
+    def _fit(self, X):
+        self.received_fit_type_ = type(X)
+        self.max_timestamp_ = X.timestamps.max()
+
+    def _predict(self, X):
+        self.received_predict_type_ = type(X)
+        return scipy.sparse.csr_matrix(X.binary_values)
+
+
+def test_time_aware_algorithm_passes_interaction_matrix_to_fit_and_predict(matrix_sessions):
+    algo = _DummyTimeAware()
+
+    algo.fit(matrix_sessions)
+    assert algo.received_fit_type_ == InteractionMatrix
+    assert algo.max_timestamp_ == matrix_sessions.timestamps.max()
+
+    X_pred = algo.predict(matrix_sessions)
+    assert algo.received_predict_type_ == InteractionMatrix
+    assert isinstance(X_pred, scipy.sparse.csr_matrix)
+
+
+def test_time_aware_algorithm_rejects_csr_matrix(matrix_sessions):
+    algo = _DummyTimeAware()
+
+    with pytest.raises(TypeError) as type_error:
+        algo.fit(matrix_sessions.binary_values)
+
+    assert type_error.match(".* requires Interaction Matrix as input.")
+
+
+def test_time_aware_algorithm_rejects_interaction_matrix_without_timestamps(X_in):
+    algo = _DummyTimeAware()
+
+    with pytest.raises(ValueError) as value_error:
+        algo.fit(InteractionMatrix.from_csr_matrix(X_in))
+
+    assert value_error.match(".* requires timestamp information in the InteractionMatrix.")

--- a/recpack/tests/test_algorithms/test_baseline.py
+++ b/recpack/tests/test_algorithms/test_baseline.py
@@ -7,10 +7,12 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 import pytest
 from scipy.sparse import csr_matrix
 
-from recpack.algorithms import Popularity, Random
+from recpack.algorithms import Popularity, Random, TimeAwarePopularity
+from recpack.matrix import InteractionMatrix
 
 
 def test_random(X_in):
@@ -74,3 +76,94 @@ def test_popularity_K_larger_than_num_items():
         algo.fit(train_data)
         assert len(w) > 0
         assert "K is larger than the number of items." in str(w[-1].message)
+
+
+def _make_timed_interaction_matrix(users, items, timestamps, shape):
+    df = pd.DataFrame(
+        {
+            InteractionMatrix.USER_IX: users,
+            InteractionMatrix.ITEM_IX: items,
+            InteractionMatrix.TIMESTAMP_IX: timestamps,
+        }
+    )
+    return InteractionMatrix(
+        df,
+        InteractionMatrix.ITEM_IX,
+        InteractionMatrix.USER_IX,
+        timestamp_ix=InteractionMatrix.TIMESTAMP_IX,
+        shape=shape,
+    )
+
+
+def test_time_aware_popularity_no_decay_matches_popularity():
+    item_i = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
+    user_i = [0, 1, 2, 3, 4, 0, 1, 2, 3, 4]
+    timestamps = list(range(10))
+    shape = (5, 5)
+
+    X = _make_timed_interaction_matrix(user_i, item_i, timestamps, shape)
+
+    algo = TimeAwarePopularity(K=5, decay=None)
+    algo.fit(X)
+
+    pop = Popularity(K=5)
+    pop.fit(csr_matrix(([1] * 10, (user_i, item_i)), shape=shape))
+
+    # Without decay every interaction gets weight 1,
+    # so scores match plain count-based popularity.
+    np.testing.assert_almost_equal(algo.sorted_scores_, pop.sorted_scores_)
+
+
+def test_time_aware_popularity_decay_boosts_recent_items():
+    # Item 1 has three old interactions, item 2 has two recent ones.
+    user_i = [0, 1, 2, 3, 4]
+    item_i = [1, 1, 1, 2, 2]
+    timestamps = [0, 0, 0, 100, 100]
+    shape = (5, 5)
+
+    X = _make_timed_interaction_matrix(user_i, item_i, timestamps, shape)
+
+    no_decay = TimeAwarePopularity(K=5, decay=None)
+    no_decay.fit(X)
+    # Without decay, raw counts win: item 1 > item 2.
+    assert no_decay.sorted_scores_[1] > no_decay.sorted_scores_[2]
+
+    strong_decay = TimeAwarePopularity(K=5, decay=10.0)
+    strong_decay.fit(X)
+    # With strong decay the old interactions are worth almost nothing,
+    # so the recently popular item 2 ranks first.
+    assert strong_decay.sorted_scores_[2] > strong_decay.sorted_scores_[1]
+
+
+def test_time_aware_popularity_rejects_csr_matrix(X_in):
+    algo = TimeAwarePopularity(K=2)
+
+    with pytest.raises(TypeError) as type_error:
+        algo.fit(X_in)
+
+    assert type_error.match(".* requires Interaction Matrix as input.")
+
+
+def test_time_aware_popularity_rejects_matrix_without_timestamps(X_in):
+    algo = TimeAwarePopularity(K=2)
+
+    with pytest.raises(ValueError) as value_error:
+        algo.fit(InteractionMatrix.from_csr_matrix(X_in))
+
+    assert value_error.match(".* requires timestamp information in the InteractionMatrix.")
+
+
+def test_time_aware_popularity_predict_rejects_matrix_without_timestamps(X_in):
+    user_i = [0, 1, 2, 3, 4]
+    item_i = [1, 1, 1, 2, 2]
+    timestamps = [0, 0, 0, 100, 100]
+
+    X = _make_timed_interaction_matrix(user_i, item_i, timestamps, (10, 5))
+
+    algo = TimeAwarePopularity(K=2)
+    algo.fit(X)
+
+    with pytest.raises(ValueError) as value_error:
+        algo.predict(InteractionMatrix.from_csr_matrix(X_in))
+
+    assert value_error.match(".* requires timestamp information in the InteractionMatrix.")


### PR DESCRIPTION
## Description

Closes the "Make time information accessible to algorithms" task.

Currently, RecPack converts all input to a binary `csr_matrix` before calling
`_fit` and `_predict`, discarding the timestamp information carried by the
`InteractionMatrix`. This makes it impossible to write algorithms whose
training or prediction logic depends on *when* interactions happened.

This PR adds a new base class, `TimeAwareAlgorithm`, whose `_fit` and
`_predict` receive the full `InteractionMatrix` — timestamps included — plus a
ready-made `TimeAwarePopularity` baseline that demonstrates it.

## Changes

- **`recpack/algorithms/base.py`** — new `TimeAwareAlgorithm(Algorithm)`:
  - `_transform_fit_input` / `_transform_predict_input` validate instead of
    convert: `TypeError` if the input is not an `InteractionMatrix`,
    `ValueError` if it has no timestamps, then pass the matrix through
    unchanged. Datasets without time information are rejected explicitly
    instead of silently misbehaving.
  - `_check_prediction` overridden to use `X.active_users`
    (`InteractionMatrix` has no `.nonzero()`).
- **`recpack/algorithms/baseline.py`** — new `TimeAwarePopularity(K=200, decay=None)`:
  - Each interaction is weighted by `exp(-(t_max - t) / decay)`; item scores
    are the sum of weights, normalized to `[0, 1]`.
  - With `decay=None` every interaction weighs 1, reproducing plain
    `Popularity` exactly.
- **`recpack/algorithms/__init__.py`** — exports both classes;
  `TimeAwarePopularity` is auto-registered in `ALGORITHM_REGISTRY`, so it is
  usable from pipelines with no further changes.

## Usage

```python
from recpack.algorithms import TimeAwarePopularity

algo = TimeAwarePopularity(K=100, decay=86400.0)  # ~1 day time scale
algo.fit(interaction_matrix_with_timestamps)