### PR TITLE
Add per-step seeds for Scenarios

### DIFF
--- a/recpack/scenarios/scenario_base.py
+++ b/recpack/scenarios/scenario_base.py
@@ -7,7 +7,7 @@
 
 from abc import ABC, abstractmethod
 import numpy as np
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 from warnings import warn
 
 from recpack.scenarios.splitters import StrongGeneralizationSplitter
@@ -26,22 +26,51 @@ class Scenario(ABC):
     should follow the same splitting strategy as
     the one used to create training and test datasets from the full dataset.
 
+    In addition to the top-level ``seed``, each random splitting step can be
+    seeded independently. This makes it possible to e.g. keep the training
+    dataset fixed across runs, while resampling only the test fold-in/hold-out
+    split, or to resample only the validation datasets.
+    Any of the per-step seeds that is left as None defaults to ``seed``,
+    so passing only ``seed`` behaves exactly as before.
+
     :param validation: Create validation datasets when True,
         else split into training and test datasets.
     :type validation: boolean, optional
     :param seed: Seed for randomisation parts of the scenario.
+        Used as fallback for the per-step seeds below.
         Defaults to None, so random seed will be generated.
     :type seed: int, optional
+    :param train_test_seed: Seed for the train/test split.
+        Defaults to None, which falls back to ``seed``.
+    :type train_test_seed: int, optional
+    :param validation_seed: Seed for the validation splits (both the split of
+        the training data into validation-train and validation data,
+        and the validation fold-in/hold-out split).
+        Defaults to None, which falls back to ``seed``.
+    :type validation_seed: int, optional
+    :param test_split_seed: Seed for the test fold-in/hold-out split.
+        Defaults to None, which falls back to ``seed``.
+    :type test_split_seed: int, optional
     """
 
-    def __init__(self, validation=False, seed=None):
+    def __init__(
+        self,
+        validation=False,
+        seed=None,
+        train_test_seed: Optional[int] = None,
+        validation_seed: Optional[int] = None,
+        test_split_seed: Optional[int] = None,
+    ):
         if seed is None:
             # Set seed if it was not set before.
             seed = np.random.get_state()[1][0]
         self.seed = seed
+        self.train_test_seed = train_test_seed if train_test_seed is not None else self.seed
+        self.validation_seed = validation_seed if validation_seed is not None else self.seed
+        self.test_split_seed = test_split_seed if test_split_seed is not None else self.seed
         self.validation = validation
         if validation:
-            self.validation_splitter = StrongGeneralizationSplitter(0.8, seed=self.seed)
+            self.validation_splitter = StrongGeneralizationSplitter(0.8, seed=self.validation_seed)
 
     @abstractmethod
     def _split(self, data_m: InteractionMatrix) -> None:

--- a/recpack/scenarios/strong_generalization.py
+++ b/recpack/scenarios/strong_generalization.py
@@ -5,6 +5,8 @@
 #   Lien Michiels
 #   Robin Verachtert
 
+from typing import Optional
+
 from recpack.matrix import InteractionMatrix
 from recpack.scenarios import Scenario
 from recpack.scenarios.splitters import FractionInteractionSplitter, StrongGeneralizationSplitter
@@ -91,8 +93,21 @@ class StrongGeneralization(Scenario):
         else split without validation data into only a training and test dataset.
     :type validation: boolean, optional
     :param seed: The seed to use for the random components of the splitter.
+        Used as fallback for the per-step seeds below.
         If None, a random seed will be used. Defaults to None
     :type seed: int, optional
+    :param train_test_seed: Seed for the assignment of users to
+        the training or test group.
+        Defaults to None, which falls back to ``seed``.
+    :type train_test_seed: int, optional
+    :param validation_seed: Seed for the validation splits (both the
+        assignment of training users to the validation group,
+        and the validation fold-in/hold-out split).
+        Defaults to None, which falls back to ``seed``.
+    :type validation_seed: int, optional
+    :param test_split_seed: Seed for the test fold-in/hold-out split.
+        Defaults to None, which falls back to ``seed``.
+    :type test_split_seed: int, optional
     """
 
     def __init__(
@@ -101,13 +116,27 @@ class StrongGeneralization(Scenario):
         frac_interactions_in: float = 0.8,
         validation: bool = False,
         seed: int = None,
+        train_test_seed: Optional[int] = None,
+        validation_seed: Optional[int] = None,
+        test_split_seed: Optional[int] = None,
     ):
-        super().__init__(validation=validation, seed=seed)
+        super().__init__(
+            validation=validation,
+            seed=seed,
+            train_test_seed=train_test_seed,
+            validation_seed=validation_seed,
+            test_split_seed=test_split_seed,
+        )
         self.frac_users_train = frac_users_train
         self.frac_interactions_in = frac_interactions_in
 
-        self.strong_gen = StrongGeneralizationSplitter(frac_users_train, seed=self.seed)
-        self.interaction_split = FractionInteractionSplitter(frac_interactions_in, seed=self.seed)
+        self.strong_gen = StrongGeneralizationSplitter(frac_users_train, seed=self.train_test_seed)
+        self.test_interaction_split = FractionInteractionSplitter(frac_interactions_in, seed=self.test_split_seed)
+        self.validation_interaction_split = FractionInteractionSplitter(
+            frac_interactions_in, seed=self.validation_seed
+        )
+        # Kept as an alias for backward compatibility.
+        self.interaction_split = self.test_interaction_split
 
     def _split(self, data: InteractionMatrix) -> None:
         """Splits your data so that a user can only be in one of
@@ -127,6 +156,6 @@ class StrongGeneralization(Scenario):
             (
                 self._validation_data_in,
                 self._validation_data_out,
-            ) = self.interaction_split.split(validation_data)
+            ) = self.validation_interaction_split.split(validation_data)
 
-        self._test_data_in, self._test_data_out = self.interaction_split.split(test_data)
+        self._test_data_in, self._test_data_out = self.test_interaction_split.split(test_data)

--- a/recpack/scenarios/weak_generalization.py
+++ b/recpack/scenarios/weak_generalization.py
@@ -5,6 +5,8 @@
 #   Lien Michiels
 #   Robin Verachtert
 
+from typing import Optional
+
 from recpack.matrix import InteractionMatrix
 from recpack.scenarios import Scenario
 from recpack.scenarios.splitters import FractionInteractionSplitter
@@ -80,8 +82,24 @@ class WeakGeneralization(Scenario):
         else split without validation data into only a training and test dataset.
     :type validation: boolean, optional
     :param seed: The seed to use for the random components of the splitter.
+        Used as fallback for the per-step seeds below.
         If None, a random seed will be used. Defaults to None
     :type seed: int, optional
+    :param train_test_seed: Seed for the split of the full dataset into
+        the full training data and the test hold-out.
+        In this scenario this single split determines both the training set
+        and the test data.
+        Defaults to None, which falls back to ``seed``.
+    :type train_test_seed: int, optional
+    :param validation_seed: Seed for the split of the full training data
+        into validation training and validation hold-out data.
+        Defaults to None, which falls back to ``seed``.
+    :type validation_seed: int, optional
+    :param test_split_seed: Accepted for API consistency with the other
+        scenarios. The test fold-in data is a copy of the full training data
+        in this scenario, so this seed drives no additional random step.
+        Defaults to None, which falls back to ``seed``.
+    :type test_split_seed: int, optional
     """
 
     def __init__(
@@ -89,17 +107,26 @@ class WeakGeneralization(Scenario):
         frac_data_in: float = 0.8,
         validation: bool = False,
         seed: int = None,
+        train_test_seed: Optional[int] = None,
+        validation_seed: Optional[int] = None,
+        test_split_seed: Optional[int] = None,
     ):
-        super().__init__(validation=validation, seed=seed)
+        super().__init__(
+            validation=validation,
+            seed=seed,
+            train_test_seed=train_test_seed,
+            validation_seed=validation_seed,
+            test_split_seed=test_split_seed,
+        )
 
         self.frac_data_in = frac_data_in
 
-        self.interaction_split = FractionInteractionSplitter(self.frac_data_in, seed=self.seed)
+        self.interaction_split = FractionInteractionSplitter(self.frac_data_in, seed=self.train_test_seed)
 
         if validation:
             self.validation_splitter = FractionInteractionSplitter(
                 self.frac_data_in,
-                seed=self.seed,
+                seed=self.validation_seed,
             )
 
     def _split(self, data: InteractionMatrix):

--- a/recpack/tests/test_scenarios/test_strong_generalization_scenario.py
+++ b/recpack/tests/test_scenarios/test_strong_generalization_scenario.py
@@ -116,3 +116,85 @@ def test_strong_generalization_split_seed(data_m, frac_users_train, frac_interac
 
     assert scenario_1.test_data_in.num_interactions == scenario_2.test_data_in.num_interactions
     assert scenario_1.test_data_out.num_interactions == scenario_2.test_data_out.num_interactions
+
+
+def _interaction_pairs(data_m):
+    """The (user, item) pairs of an InteractionMatrix as a set."""
+    return set(zip(data_m.indices[0], data_m.indices[1]))
+
+
+def test_strong_generalization_separate_seeds_train_test_fixed_test_split_varies(data_m):
+    scenario_1 = scenarios.StrongGeneralization(0.7, 0.5, train_test_seed=42, test_split_seed=1)
+    scenario_2 = scenarios.StrongGeneralization(0.7, 0.5, train_test_seed=42, test_split_seed=2)
+
+    scenario_1.split(data_m)
+    scenario_2.split(data_m)
+
+    # Same train_test_seed -> identical training data and identical test users.
+    assert _interaction_pairs(scenario_1.full_training_data) == _interaction_pairs(scenario_2.full_training_data)
+
+    test_users_1 = scenario_1.test_data_in.active_users | scenario_1.test_data_out.active_users
+    test_users_2 = scenario_2.test_data_in.active_users | scenario_2.test_data_out.active_users
+    assert test_users_1 == test_users_2
+
+    # The test interactions are the same, ...
+    test_pairs_1 = _interaction_pairs(scenario_1.test_data_in) | _interaction_pairs(scenario_1.test_data_out)
+    test_pairs_2 = _interaction_pairs(scenario_2.test_data_in) | _interaction_pairs(scenario_2.test_data_out)
+    assert test_pairs_1 == test_pairs_2
+
+    # ... but a different test_split_seed assigns them differently
+    # to the fold-in and hold-out sets.
+    assert _interaction_pairs(scenario_1.test_data_in) != _interaction_pairs(scenario_2.test_data_in)
+
+
+def test_strong_generalization_separate_seeds_train_test_varies_test_split_fixed(data_m):
+    scenario_1 = scenarios.StrongGeneralization(0.7, 0.5, train_test_seed=1, test_split_seed=42)
+    scenario_2 = scenarios.StrongGeneralization(0.7, 0.5, train_test_seed=2, test_split_seed=42)
+
+    scenario_1.split(data_m)
+    scenario_2.split(data_m)
+
+    # A different train_test_seed changes which users are in training.
+    train_users_1 = set(scenario_1.full_training_data.indices[0])
+    train_users_2 = set(scenario_2.full_training_data.indices[0])
+    assert train_users_1 != train_users_2
+
+
+def test_strong_generalization_only_seed_still_reproducible(data_m):
+    # Backward compatibility: only passing seed fully determines every split.
+    scenario_1 = scenarios.StrongGeneralization(0.7, 0.5, validation=True, seed=42)
+    scenario_2 = scenarios.StrongGeneralization(0.7, 0.5, validation=True, seed=42)
+
+    scenario_1.split(data_m)
+    scenario_2.split(data_m)
+
+    assert _interaction_pairs(scenario_1.full_training_data) == _interaction_pairs(scenario_2.full_training_data)
+    assert _interaction_pairs(scenario_1.validation_training_data) == _interaction_pairs(
+        scenario_2.validation_training_data
+    )
+    assert _interaction_pairs(scenario_1.validation_data_in) == _interaction_pairs(scenario_2.validation_data_in)
+    assert _interaction_pairs(scenario_1.validation_data_out) == _interaction_pairs(scenario_2.validation_data_out)
+    assert _interaction_pairs(scenario_1.test_data_in) == _interaction_pairs(scenario_2.test_data_in)
+    assert _interaction_pairs(scenario_1.test_data_out) == _interaction_pairs(scenario_2.test_data_out)
+
+
+def test_strong_generalization_validation_seed_isolates_validation(data_m):
+    scenario_1 = scenarios.StrongGeneralization(
+        0.7, 0.5, validation=True, train_test_seed=42, test_split_seed=42, validation_seed=1
+    )
+    scenario_2 = scenarios.StrongGeneralization(
+        0.7, 0.5, validation=True, train_test_seed=42, test_split_seed=42, validation_seed=2
+    )
+
+    scenario_1.split(data_m)
+    scenario_2.split(data_m)
+
+    # Train and test data are unchanged.
+    assert _interaction_pairs(scenario_1.full_training_data) == _interaction_pairs(scenario_2.full_training_data)
+    assert _interaction_pairs(scenario_1.test_data_in) == _interaction_pairs(scenario_2.test_data_in)
+    assert _interaction_pairs(scenario_1.test_data_out) == _interaction_pairs(scenario_2.test_data_out)
+
+    # A different validation_seed produces a different validation training set.
+    assert _interaction_pairs(scenario_1.validation_training_data) != _interaction_pairs(
+        scenario_2.validation_training_data
+    )


### PR DESCRIPTION
## Description

Closes the "Add seeds for Scenarios" task.

Each evaluation scenario currently accepts a single random seed that drives
every internal splitting step (train/test split, validation in/out split,
test in/out split). This makes the whole pipeline reproducible from one
number, but tightly couples all random decisions: changing the seed to get a
different test split also changes which users end up in training. It is
therefore impossible to e.g. keep the training set fixed across runs while
resampling only the test fold to evaluate a model's robustness.

This PR exposes separate optional seeds for the internal splitters, while
keeping the single-seed API fully backward compatible.

## New API

`Scenario`, `StrongGeneralization` and `WeakGeneralization` now accept three
additional optional parameters:

- `train_test_seed` — seed for the outer train/test split.
- `validation_seed` — seed for the validation splits (both the
  validation-train/validation user split and the validation
  fold-in/hold-out split).
- `test_split_seed` — seed for the test fold-in/hold-out split.

Any seed left as `None` falls back to the top-level `seed`, so existing
callers see no behavioural change.

```python
# Same training set, different test fold-in/hold-out each run:
for test_seed in [100, 101, 102]:
    scenario = StrongGeneralization(
        frac_users_train=0.8,
        frac_interactions_in=0.8,
        train_test_seed=42,         # fixed -> same training set
        test_split_seed=test_seed,  # varies -> different test folds
    )
    scenario.split(data)