### PR TITLE
Add lightgcn

### DIFF
--- a/recpack/algorithms/__init__.py
+++ b/recpack/algorithms/__init__.py
@@ -94,6 +94,18 @@ user to reconstruct the original interaction matrix R = UV^T.
     BPRMF
 
 
+Graph Convolution Algorithms
+----------------------------
+
+Graph convolution algorithms learn user and item representations
+by propagating information over the user-item interaction graph.
+
+.. autosummary::
+    :toctree: generated/
+
+    LightGCN
+
+
 Autoencoder Algorithms
 ------------------------
 
@@ -258,6 +270,7 @@ from recpack.algorithms.slim import SLIM
 from recpack.algorithms.nearest_neighbour import ItemKNN, ItemPNN
 from recpack.algorithms.kunn import KUNN
 from recpack.algorithms.bprmf import BPRMF
+from recpack.algorithms.lightgcn import LightGCN
 
 # from recpack.algorithms.metric_learning.cml import CML
 

--- a/recpack/algorithms/base.py
+++ b/recpack/algorithms/base.py
@@ -506,7 +506,10 @@ class TorchMLAlgorithm(Algorithm):
     def _load_best(self):
         """Load the best model from temp file"""
         self.best_model.seek(0)
-        self.model_ = torch.load(self.best_model)
+        # weights_only=False is required since torch 2.6 to unpickle
+        # full model objects. The file was written by this process in
+        # _save_best, so it is trusted.
+        self.model_ = torch.load(self.best_model, weights_only=False)
 
     def _evaluate(self, val_in: Matrix, val_out: Matrix) -> None:
         """Perform evaluation step
@@ -628,11 +631,15 @@ class TorchMLAlgorithm(Algorithm):
     def load(self, filename):
         """Load torch model from file.
 
+        Only load models from trusted sources: the file is unpickled
+        (``weights_only=False``), which can execute arbitrary code
+        embedded in a malicious file.
+
         :param filename: File to load the model from
         :type filename: str
         """
         with open(filename, "rb") as f:
-            self.model_ = torch.load(f)
+            self.model_ = torch.load(f, weights_only=False)
 
     def save(self):
         """Save the current model to disk.

--- a/recpack/algorithms/lightgcn.py
+++ b/recpack/algorithms/lightgcn.py
@@ -1,0 +1,346 @@
+# RecPack, An Experimentation Toolkit for Top-N Recommendation
+# Copyright (C) 2020  Froomle N.V.
+# License: GNU AGPLv3 - https://gitlab.com/recpack-maintainers/recpack/-/blob/master/LICENSE
+# Author:
+#   Lien Michiels
+#   Robin Verachtert
+
+import logging
+from typing import List
+
+import numpy as np
+import scipy.sparse as sp
+from scipy.sparse import csr_matrix, lil_matrix
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from tqdm.auto import tqdm
+
+from recpack.algorithms.base import TorchMLAlgorithm
+from recpack.algorithms.loss_functions import bpr_loss
+from recpack.algorithms.samplers import BootstrapSampler
+from recpack.util import to_binary
+
+logger = logging.getLogger("recpack")
+
+
+class LightGCN(TorchMLAlgorithm):
+    """LightGCN graph convolution algorithm for collaborative filtering.
+
+    LightGCN as presented in He, Xiangnan, et al.
+    "LightGCN: Simplifying and powering graph convolution network for
+    recommendation." SIGIR 2020.
+
+    User and item embeddings are smoothed by propagating them over the
+    normalized user-item interaction graph. Each propagation layer computes
+
+    .. math::
+
+        E^{(k+1)} = (D^{-1/2} A D^{-1/2}) E^{(k)}
+
+    where :math:`A` is the adjacency matrix of the bipartite interaction
+    graph and :math:`D` its degree matrix.
+    The final representation of a user or item is the mean of its
+    embeddings at every layer :math:`0..K`.
+    Scores are the dot products of the final user and item embeddings.
+
+    Training optimises the BPR criterion on sampled (user, positive item,
+    negative item) triplets, with L2 regularization on the layer-0
+    (ego) embeddings of the sampled entities.
+
+    :param num_components: The size of the latent vectors for both users and items.
+        Defaults to 64
+    :type num_components: int, optional
+    :param num_layers: The number of graph convolution (propagation) layers.
+        Defaults to 3
+    :type num_layers: int, optional
+    :param lambda_reg: L2 regularization coefficient applied to the ego
+        embeddings of the entities in each training batch. Defaults to 1e-4
+    :type lambda_reg: float, optional
+    :param batch_size: Size of the batches to use during gradient descent. Defaults to 1000.
+    :type batch_size: int, optional
+    :param max_epochs: The max amount of epochs to train the model, defaults to 20
+    :type max_epochs: int, optional
+    :param learning_rate: The learning rate of the optimization procedure,
+        defaults to 0.001
+    :type learning_rate: float, optional
+    :param stopping_criterion: Which criterion to use to optimise the parameters,
+        a string which indicates the name of the stopping criterion.
+        Which criterions are available can be found at
+        :attr:`recpack.algorithms.stopping_criterion.StoppingCriterion.FUNCTIONS`.
+        Defaults to 'bpr'
+    :type stopping_criterion: str, optional
+    :param stop_early: If True, early stopping is enabled,
+        and after ``max_iter_no_change`` iterations where improvement of loss function
+        is below ``min_improvement`` the optimisation is stopped,
+        even if max_epochs is not reached.
+        Defaults to False
+    :type stop_early: bool, optional
+    :param max_iter_no_change: If early stopping is enabled,
+        stop after this amount of iterations without change.
+        Defaults to 5
+    :type max_iter_no_change: int, optional
+    :param min_improvement: If early stopping is enabled, no change is detected,
+        if the improvement is below this value.
+        Defaults to 0.01
+    :type min_improvement: float, optional
+    :param seed: Seed to fix random numbers, to make results reproducible,
+        defaults to None
+    :type seed: int, optional
+    :param save_best_to_file: If True, the best model is saved to disk after fit.
+    :type save_best_to_file: bool, optional
+    :param sample_size: How many samples to take during a training epoch
+        using bootstrap sampling.
+        If None a sample is taken for each interaction,
+        there is no guarantee that all interactions will be used though,
+        since sampling happens with replacement.
+        Defaults to None
+    :type sample_size: int, optional
+    :param keep_last: Retain last model, rather than best
+        (according to stopping criterion value on validation data), defaults to False
+    :type keep_last: bool, optional
+    :param predict_topK: The topK recommendations to keep per row in the matrix.
+        Use when the user x item output matrix would become too large for RAM.
+        Defaults to None, which results in no filtering.
+    :type predict_topK: int, optional
+    :param validation_sample_size: Amount of users that will be sampled to calculate
+        validation loss and stopping criterion value.
+        This reduces computation time during validation, such that training times are strongly reduced.
+        If None, all nonzero users are used. Defaults to None.
+    :type validation_sample_size: int, optional
+    """
+
+    def __init__(
+        self,
+        num_components: int = 64,
+        num_layers: int = 3,
+        lambda_reg: float = 1e-4,
+        batch_size: int = 1_000,
+        max_epochs: int = 20,
+        learning_rate: float = 0.001,
+        stopping_criterion: str = "bpr",
+        stop_early: bool = False,
+        max_iter_no_change: int = 5,
+        min_improvement: float = 0.01,
+        seed: int = None,
+        save_best_to_file: bool = False,
+        sample_size: int = None,
+        keep_last: bool = False,
+        predict_topK: int = None,
+        validation_sample_size: int = None,
+    ):
+        super().__init__(
+            batch_size,
+            max_epochs,
+            learning_rate,
+            stopping_criterion,
+            stop_early=stop_early,
+            max_iter_no_change=max_iter_no_change,
+            min_improvement=min_improvement,
+            seed=seed,
+            save_best_to_file=save_best_to_file,
+            keep_last=keep_last,
+            predict_topK=predict_topK,
+            validation_sample_size=validation_sample_size,
+        )
+
+        self.num_components = num_components
+        self.num_layers = num_layers
+        self.lambda_reg = lambda_reg
+
+        self.sample_size = sample_size
+
+        self.sampler = BootstrapSampler(
+            num_negatives=1,
+            batch_size=self.batch_size,
+        )
+
+    def _init_model(self, X: csr_matrix):
+        num_users, num_items = X.shape
+        self.model_ = LightGCNModule(
+            num_users,
+            num_items,
+            X,
+            num_components=self.num_components,
+            num_layers=self.num_layers,
+        ).to(self.device)
+
+        self.optimizer = optim.Adam(self.model_.parameters(), lr=self.learning_rate)
+
+    def _batch_predict(self, X: csr_matrix, users: List[int]) -> csr_matrix:
+        """Predict scores for matrix X, given the selected users in this batch
+
+        :param X: Matrix of user item interactions,
+            expected to only contain interactions for those users that are in `users`
+        :type X: csr_matrix
+        :param users: users selected for recommendation
+        :type users: List[int]
+        :return: Sparse matrix of scores per user item pair.
+        :rtype: csr_matrix
+        """
+        user_tensor = torch.LongTensor(users).to(self.device)
+        item_tensor = torch.arange(X.shape[1]).to(self.device)
+
+        result = lil_matrix(X.shape)
+        result[users] = self.model_(user_tensor, item_tensor).detach().cpu().numpy()
+
+        return result.tocsr()
+
+    def _train_epoch(self, train_data: csr_matrix):
+        """Train a single epoch. Uses sampler to generate samples,
+        and loop through them in batches of self.batch_size.
+        After each batch, update the parameters according to gradients.
+
+        :param train_data: interaction matrix.
+        :type train_data: csr_matrix
+        """
+        losses = []
+
+        for users, target_items, mnar_items in tqdm(
+            self.sampler.sample(
+                train_data,
+                sample_size=self.sample_size,
+            ),
+            desc="train_epoch LightGCN",
+        ):
+            users = users.to(self.device)
+            # Target items are items the user has interacted with,
+            # and we expect to recommend high
+            target_items = target_items.to(self.device)
+            # Items the user has not seen, and assuming MNAR data
+            # Is a batch_size x 1 matrix, squeeze into an array.
+            mnar_items = mnar_items.squeeze(-1).to(self.device)
+
+            self.optimizer.zero_grad()
+
+            user_final, item_final = self.model_.propagate()
+
+            positive_sim = (user_final[users] * item_final[target_items]).sum(dim=1)
+            negative_sim = (user_final[users] * item_final[mnar_items]).sum(dim=1)
+
+            loss = self._compute_loss(users, target_items, mnar_items, positive_sim, negative_sim)
+            loss.backward()
+            losses.append(loss.item())
+            self.optimizer.step()
+
+        return losses
+
+    def _compute_loss(self, users, target_items, mnar_items, positive_sim, negative_sim):
+        loss = bpr_loss(positive_sim, negative_sim)
+
+        # L2 regularization on the ego (layer 0) embeddings of the batch,
+        # as in the LightGCN paper.
+        reg = (
+            self.model_.user_embedding_(users).pow(2).sum()
+            + self.model_.item_embedding_(target_items).pow(2).sum()
+            + self.model_.item_embedding_(mnar_items).pow(2).sum()
+        )
+        loss = loss + self.lambda_reg * reg / users.shape[0]
+
+        return loss
+
+
+class LightGCNModule(nn.Module):
+    """LightGCN torch module, encodes the embeddings
+    and the graph propagation functionality.
+
+    :param num_users: the amount of users
+    :type num_users: int
+    :param num_items: the amount of items
+    :type num_items: int
+    :param X: Binary user-item interaction matrix used to construct
+        the normalized adjacency matrix of the propagation graph.
+    :type X: csr_matrix
+    :param num_components: The size of the embedding per user and item, defaults to 64
+    :type num_components: int, optional
+    :param num_layers: The number of propagation layers, defaults to 3
+    :type num_layers: int, optional
+    """
+
+    def __init__(self, num_users: int, num_items: int, X: csr_matrix, num_components: int = 64, num_layers: int = 3):
+        super().__init__()
+
+        self.num_components = num_components
+        self.num_users = num_users
+        self.num_items = num_items
+        self.num_layers = num_layers
+
+        self.user_embedding_ = nn.Embedding(num_users, num_components)
+        self.item_embedding_ = nn.Embedding(num_items, num_components)
+
+        # Keep variance low enough, to allow learning
+        self.std = min(1 / num_components ** 0.5, 0.05)
+        nn.init.normal_(self.user_embedding_.weight, std=self.std)
+        nn.init.normal_(self.item_embedding_.weight, std=self.std)
+
+        # register_buffer makes the adjacency move along
+        # with the module between devices, and be saved with it.
+        self.register_buffer("norm_adjacency", self._normalized_adjacency(X))
+
+        self._cached_propagation = None
+
+    def _normalized_adjacency(self, X: csr_matrix) -> torch.Tensor:
+        """Construct the symmetrically normalized adjacency matrix
+        D^-1/2 A D^-1/2 of the bipartite interaction graph as a
+        torch sparse tensor.
+        """
+        R = to_binary(csr_matrix(X))
+        A = sp.bmat([[None, R], [R.T, None]], format="csr")
+
+        degrees = np.asarray(A.sum(axis=1)).flatten()
+        with np.errstate(divide="ignore"):
+            d_inv_sqrt = np.power(degrees, -0.5)
+        # Users or items without interactions have degree 0.
+        d_inv_sqrt[np.isinf(d_inv_sqrt)] = 0
+
+        D_inv_sqrt = sp.diags(d_inv_sqrt)
+        A_norm = (D_inv_sqrt @ A @ D_inv_sqrt).tocoo()
+
+        indices = torch.LongTensor(np.vstack([A_norm.row, A_norm.col]))
+        values = torch.FloatTensor(A_norm.data)
+
+        return torch.sparse_coo_tensor(indices, values, A_norm.shape).coalesce()
+
+    def train(self, mode: bool = True):
+        # Embeddings change with every update,
+        # so a cached propagation is no longer valid.
+        self._cached_propagation = None
+        return super().train(mode)
+
+    def propagate(self):
+        """Propagate the ego embeddings through the graph.
+
+        :return: The final user and item embeddings,
+            the mean over the embeddings at every layer.
+        :rtype: Tuple[torch.Tensor, torch.Tensor]
+        """
+        if not self.training and self._cached_propagation is not None:
+            return self._cached_propagation
+
+        embeddings = torch.cat([self.user_embedding_.weight, self.item_embedding_.weight], dim=0)
+        all_layers = [embeddings]
+
+        for _ in range(self.num_layers):
+            embeddings = torch.sparse.mm(self.norm_adjacency, embeddings)
+            all_layers.append(embeddings)
+
+        final = torch.stack(all_layers, dim=0).mean(dim=0)
+        user_final, item_final = torch.split(final, [self.num_users, self.num_items], dim=0)
+
+        if not self.training:
+            self._cached_propagation = (user_final, item_final)
+
+        return user_final, item_final
+
+    def forward(self, user_tensor: torch.Tensor, item_tensor: torch.Tensor) -> torch.Tensor:
+        """Compute the dot product of the final (propagated) user and item
+        embeddings for every user and item pair in user_tensor and item_tensor.
+
+        :param user_tensor: 1D tensor with user ids.
+        :type user_tensor: torch.Tensor
+        :param item_tensor: 1D tensor with item ids.
+        :type item_tensor: torch.Tensor
+        """
+        user_final, item_final = self.propagate()
+
+        return user_final[user_tensor].matmul(item_final[item_tensor].T)

--- a/recpack/algorithms/stan.py
+++ b/recpack/algorithms/stan.py
@@ -250,7 +250,7 @@ class STAN(Algorithm):
             # so wether it is 1 or 0 does not impact the reproduction results.
             # Because recpack does not always remove history items,
             # it makes more sense to not recommend this last matching item as well.
-            item_weights = neighborhood_positions - (neighborhood_positions > 0).multiply(last_match.A)
+            item_weights = neighborhood_positions - (neighborhood_positions > 0).multiply(last_match.toarray())
 
             item_weights.data = np.exp(-np.abs(item_weights.data) * self.distance_from_match_decay)
 

--- a/recpack/tests/test_algorithms/test_algorithms_base.py
+++ b/recpack/tests/test_algorithms/test_algorithms_base.py
@@ -165,5 +165,13 @@ def test_sampled_validation(algo_class, larger_mat):
 
     for c in mock.update.call_args_list:
         val_out, X_pred = c.args
-        assert len(set(val_out.nonzero()[0])) == N_SAMPLES
-        assert len(set(X_pred.nonzero()[0])) == N_SAMPLES
+        sampled_users = set(val_out.nonzero()[0])
+        assert len(sampled_users) == N_SAMPLES
+
+        # Predictions are made for the sampled users only.
+        # Not every algorithm can guarantee a recommendation for every user
+        # (e.g. Prod2VecClustered only recommends items from neighbouring
+        # clusters), so the predicted users are a subset of the sample.
+        predicted_users = set(X_pred.nonzero()[0])
+        assert predicted_users
+        assert predicted_users <= sampled_users

--- a/recpack/tests/test_algorithms/test_algorithms_base.py
+++ b/recpack/tests/test_algorithms/test_algorithms_base.py
@@ -27,6 +27,7 @@ from recpack.algorithms import (
     Prod2Vec,
     Prod2VecClustered,
     ItemPNN,
+    LightGCN,
 )
 
 
@@ -74,6 +75,7 @@ def test_check_fit_complete(X_in):
         RecVAE,
         MultVAE,
         BPRMF,
+        LightGCN,
         Random,
         NMFItemToItem,
         NMF,
@@ -96,6 +98,7 @@ def test_seed_is_set_consistently_None(algo):
         RecVAE,
         MultVAE,
         BPRMF,
+        LightGCN,
         Random,
         NMFItemToItem,
         NMF,
@@ -145,7 +148,7 @@ def test_assert_has_timestamps(algo_class, matrix_sessions):
 
 @pytest.mark.parametrize(
     "algo_class",
-    [RecVAE, MultVAE, BPRMF, Prod2Vec, Prod2VecClustered, GRU4RecNegSampling, GRU4RecCrossEntropy],
+    [RecVAE, MultVAE, BPRMF, LightGCN, Prod2Vec, Prod2VecClustered, GRU4RecNegSampling, GRU4RecCrossEntropy],
 )
 def test_sampled_validation(algo_class, larger_mat):
     N_SAMPLES = 50

--- a/recpack/tests/test_algorithms/test_lightgcn.py
+++ b/recpack/tests/test_algorithms/test_lightgcn.py
@@ -1,0 +1,167 @@
+# RecPack, An Experimentation Toolkit for Top-N Recommendation
+# Copyright (C) 2020  Froomle N.V.
+# License: GNU AGPLv3 - https://gitlab.com/recpack-maintainers/recpack/-/blob/master/LICENSE
+# Author:
+#   Lien Michiels
+#   Robin Verachtert
+
+import os
+
+import numpy as np
+import pytest
+from scipy.sparse import csr_matrix
+import torch
+
+from recpack.algorithms import LightGCN
+from recpack.algorithms.lightgcn import LightGCNModule
+
+
+@pytest.fixture(scope="function")
+def X_in_for_pairwise():
+    pv_users, pv_items, pv_values = (
+        [0, 0, 0, 1, 1, 1, 3, 3, 4, 4],
+        [0, 1, 2, 0, 1, 2, 3, 4, 3, 4],
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+    )
+
+    pv = csr_matrix((pv_values, (pv_users, pv_items)), shape=(10, 5))
+
+    return pv
+
+
+def test_lightgcn(X_in):
+    a = LightGCN(num_components=2, num_layers=2, max_epochs=2, batch_size=1)
+    a.fit(X_in, (X_in, X_in))
+
+    pred = a.predict(X_in)
+
+    # Users should be the exact same.
+    assert set(pred.nonzero()[0]) == set(X_in.nonzero()[0])
+
+
+def test_lightgcn_topK(X_in):
+    a = LightGCN(num_components=2, num_layers=2, max_epochs=2, batch_size=1, predict_topK=1)
+
+    a.fit(X_in, (X_in, X_in))
+
+    pred = a.predict(X_in)
+
+    assert set(pred.nonzero()[0]) == set(X_in.nonzero()[0])
+    # Each user should receive a single recommendation
+    assert pred.nonzero()[1].shape[0] == len(set(X_in.nonzero()[0]))
+
+
+def test_lightgcn_w_interaction_mat(X_in_interaction_m):
+    a = LightGCN(num_components=2, num_layers=2, max_epochs=2, batch_size=1)
+    a.fit(X_in_interaction_m, (X_in_interaction_m, X_in_interaction_m))
+
+    pred = a.predict(X_in_interaction_m)
+
+    # Users should be the exact same.
+    assert set(pred.nonzero()[0]) == set(X_in_interaction_m.active_users)
+
+
+def test_lightgcn_normalized_adjacency(X_in_for_pairwise):
+    module = LightGCNModule(
+        X_in_for_pairwise.shape[0], X_in_for_pairwise.shape[1], X_in_for_pairwise, num_components=2, num_layers=1
+    )
+
+    adjacency = module.norm_adjacency.to_dense().numpy()
+
+    num_users = X_in_for_pairwise.shape[0]
+
+    # The adjacency matrix is symmetric.
+    np.testing.assert_almost_equal(adjacency, adjacency.T)
+
+    # The user-user and item-item blocks are zero.
+    assert not adjacency[:num_users, :num_users].any()
+    assert not adjacency[num_users:, num_users:].any()
+
+    # User 0 interacted with items 0, 1, 2: degree 3.
+    # Item 0 was interacted with by users 0, 1: degree 2.
+    np.testing.assert_almost_equal(adjacency[0, num_users + 0], 1 / (np.sqrt(3) * np.sqrt(2)))
+
+    # Users without interactions have empty rows.
+    assert not adjacency[2, :].any()
+
+
+@pytest.mark.parametrize("seed", list(range(1, 6)))
+def test_lightgcn_pairwise_ranking(X_in_for_pairwise, seed):
+    """Tests that the pairwise ranking of 2 items is correctly computed."""
+
+    a = LightGCN(
+        num_components=4,
+        num_layers=2,
+        max_epochs=10,
+        batch_size=10,
+        seed=seed,
+        learning_rate=0.2,
+        sample_size=50,
+    )
+    a.fit(X_in_for_pairwise, (X_in_for_pairwise, X_in_for_pairwise))
+    pred = a.predict(X_in_for_pairwise)
+
+    # The interaction graph has two disconnected components:
+    # users {0, 1} with items {0, 1, 2}, and users {3, 4} with items {3, 4}.
+    # Items in the user's component should be scored above the others.
+    assert pred[1, 2] > pred[1, 4]
+    assert pred[1, 1] > pred[1, 4]
+    assert pred[1, 0] > pred[1, 4]
+    assert pred[1, 2] > pred[1, 3]
+    assert pred[1, 1] > pred[1, 3]
+    assert pred[1, 0] > pred[1, 3]
+
+    assert pred[3, 3] > pred[3, 0]
+    assert pred[3, 4] > pred[3, 0]
+    assert pred[3, 3] > pred[3, 1]
+    assert pred[3, 4] > pred[3, 1]
+
+
+def test_lightgcn_save_and_load(X_in_for_pairwise):
+    a = LightGCN(
+        num_components=4,
+        num_layers=2,
+        max_epochs=1,
+        batch_size=2,
+        seed=42,
+        learning_rate=0.05,
+        save_best_to_file=True,
+    )
+
+    a.fit(X_in_for_pairwise, (X_in_for_pairwise, X_in_for_pairwise))
+
+    assert os.path.isfile(a.filename)
+
+    b = LightGCN(
+        num_components=4,
+        num_layers=2,
+        max_epochs=40,
+        batch_size=2,
+        seed=42,
+        learning_rate=0.05,
+        save_best_to_file=True,
+    )
+
+    b.load(a.filename)
+
+    np.testing.assert_array_equal(
+        a.predict(X_in_for_pairwise).toarray(),
+        b.predict(X_in_for_pairwise).toarray(),
+    )
+
+    # Cleanup
+    os.remove(a.filename)
+
+
+def test_lightgcn_seed_is_set():
+    a = LightGCN()
+    assert hasattr(a, "seed")
+
+    b = LightGCN(seed=42)
+    assert b.seed == 42
+
+
+def test_lightgcn_in_registry():
+    from recpack.pipelines.registries import ALGORITHM_REGISTRY
+
+    assert "LightGCN" in ALGORITHM_REGISTRY

--- a/recpack/tests/test_algorithms/test_stan.py
+++ b/recpack/tests/test_algorithms/test_stan.py
@@ -61,7 +61,7 @@ def test_fit(algo, mini_training_dataset):
     )
 
     expected_session_timestamps = [[3, 2, 0, 0]]
-    np.testing.assert_array_equal(algo.historical_session_timestamps_.A.T, expected_session_timestamps)
+    np.testing.assert_array_equal(algo.historical_session_timestamps_.toarray().T, expected_session_timestamps)
 
 
 def test_compute_session_similarity(algo, mini_training_dataset, mini_test_dataset):

--- a/recpack/util.py
+++ b/recpack/util.py
@@ -64,8 +64,23 @@ def get_top_K_ranks(X: csr_matrix, K: Optional[int] = None) -> csr_matrix:
         K_row_pick = min(K, ri - le) if K is not None else ri - le
 
         if K_row_pick != 0:
+            row_cols = X.indices[le:ri]
+            row_data = X.data[le:ri]
 
-            top_k_row = X.indices[le + np.argpartition(X.data[le:ri], list(range(-K_row_pick, 0)))[-K_row_pick:]]
+            if K_row_pick < ri - le:
+                # Preselect the K largest values, plus any ties at the boundary,
+                # so the tie-break below sees all tied candidates.
+                partitioned = np.argpartition(row_data, -K_row_pick)
+                cutoff = row_data[partitioned[-K_row_pick]]
+                candidates = row_data >= cutoff
+                row_cols = row_cols[candidates]
+                row_data = row_data[candidates]
+
+            # Sort ascending by value, with the column index as tie-breaker,
+            # so a tie for the last position resolves to the largest index,
+            # independent of the matrix' internal storage order.
+            order = np.lexsort((row_cols, row_data))
+            top_k_row = row_cols[order[-K_row_pick:]]
 
             for rank, col_ix in enumerate(reversed(top_k_row)):
                 U.append(row_ix)


### PR DESCRIPTION
## Description

First phase of the "expand algorithm coverage" issue: adds **LightGCN**
(He et al., *LightGCN: Simplifying and Powering Graph Convolution Network
for Recommendation*, SIGIR 2020) — the standard graph-based CF baseline in
current literature and the highest-value gap in RecPack's algorithm
coverage.

> **Merge order note:** this branch includes the commits from
> #fix-torch-load-weights-only  and #fix-scipy-sparse-compat PR
> because no `TorchMLAlgorithm` can complete `fit()` without the torch fix.
> Merge those two first and this diff reduces to just the new algorithm.

## Implementation

New module `recpack/algorithms/lightgcn.py` with two classes:

- **`LightGCNModule`** (`torch.nn.Module`) — user/item embedding tables plus
  the symmetrically normalized adjacency `D^-1/2 · A · D^-1/2` of the
  bipartite interaction graph, built once from the binary training matrix
  and registered as a torch buffer (saved/moved with the model).
  Propagation computes `E(k+1) = Â · E(k)`; the final representation is the
  mean over all K layers, per the paper. Zero-degree users/items are
  handled explicitly. The propagation result is cached in eval mode (and
  invalidated on `train()`), so batched prediction pays for one graph pass.
- **`LightGCN`** — subclasses the existing `TorchMLAlgorithm`, inheriting
  batched training, early stopping, best-model checkpointing, and pipeline
  integration. Training samples (user, positive, negative) triplets with
  the existing `BootstrapSampler` and optimises BPR loss with L2
  regularization on the batch's ego (layer-0) embeddings, following the
  paper. Adam optimizer, default `learning_rate=0.001`.

Exported from `recpack.algorithms` under a new "Graph Convolution
Algorithms" docs section, and therefore auto-registered in
`ALGORITHM_REGISTRY`:

```python
pb.add_algorithm(
    "LightGCN",
    optimisation_info=GridSearchInfo({"num_components": [64, 128], "num_layers": [2, 3]}),
)