### PR TITLE
Optimize validation prediction

### DIFF
--- a/recpack/algorithms/__init__.py
+++ b/recpack/algorithms/__init__.py
@@ -229,6 +229,7 @@ Use these to simplify certain tasks (such as batching) when creating a new algor
 .. autosummary::
     :toctree: generated/
 
+    csr_from_rows
     get_batches
     sample_rows
     naive_sparse2tensor

--- a/recpack/algorithms/base.py
+++ b/recpack/algorithms/base.py
@@ -557,7 +557,9 @@ class TorchMLAlgorithm(Algorithm):
         :type X: csr_matrix
         :param users: users selected for recommendation
         :type users: List[int]
-        :return: Sparse matrix of scores per user item pair.
+        :return: Sparse matrix of scores per user item pair,
+            compact with shape (len(users), num_items): row i corresponds
+            to users[i], not to global user id i.
         :rtype: csr_matrix
         """
         raise NotImplementedError("Please implement this function")
@@ -598,9 +600,9 @@ class TorchMLAlgorithm(Algorithm):
                     batch = csr_from_rows(X[users], users, X.shape)
 
                 batch_users.extend(users)
-                batch_results.append(
-                    self._get_top_k_recommendations(csr_matrix(self._batch_predict(batch, users=users))[users])
-                )
+                # _batch_predict returns a compact (len(users) x num_items)
+                # matrix; the single full-shape assembly happens once, below.
+                batch_results.append(self._get_top_k_recommendations(self._batch_predict(batch, users=users)))
 
         if not batch_results:
             return csr_matrix(X.shape)

--- a/recpack/algorithms/base.py
+++ b/recpack/algorithms/base.py
@@ -506,7 +506,10 @@ class TorchMLAlgorithm(Algorithm):
     def _load_best(self):
         """Load the best model from temp file"""
         self.best_model.seek(0)
-        self.model_ = torch.load(self.best_model)
+        # weights_only=False is required since torch 2.6 to unpickle
+        # full model objects. The file was written by this process in
+        # _save_best, so it is trusted.
+        self.model_ = torch.load(self.best_model, weights_only=False)
 
     def _evaluate(self, val_in: Matrix, val_out: Matrix) -> None:
         """Perform evaluation step
@@ -628,11 +631,15 @@ class TorchMLAlgorithm(Algorithm):
     def load(self, filename):
         """Load torch model from file.
 
+        Only load models from trusted sources: the file is unpickled
+        (``weights_only=False``), which can execute arbitrary code
+        embedded in a malicious file.
+
         :param filename: File to load the model from
         :type filename: str
         """
         with open(filename, "rb") as f:
-            self.model_ = torch.load(f)
+            self.model_ = torch.load(f, weights_only=False)
 
     def save(self):
         """Save the current model to disk.

--- a/recpack/algorithms/base.py
+++ b/recpack/algorithms/base.py
@@ -11,7 +11,7 @@ from typing import List, Tuple, Optional
 import warnings
 
 import numpy as np
-from scipy.sparse import csr_matrix, lil_matrix
+from scipy.sparse import csr_matrix, lil_matrix, vstack
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
 import tempfile
@@ -22,7 +22,7 @@ from recpack.algorithms.stopping_criterion import (
     EarlyStoppingException,
     StoppingCriterion,
 )
-from recpack.algorithms.util import get_batches, get_users, sample_rows
+from recpack.algorithms.util import csr_from_rows, get_batches, get_users, sample_rows
 from recpack.matrix import InteractionMatrix, to_csr_matrix, Matrix
 from recpack.util import get_top_K_values
 
@@ -587,22 +587,32 @@ class TorchMLAlgorithm(Algorithm):
         :rtype: csr_matrix
         """
 
-        results = lil_matrix(X.shape)
+        batch_users = []
+        batch_results = []
         self.model_.eval()
         with torch.no_grad():
             for users in get_batches(get_users(X), batch_size=self.batch_size):
                 if isinstance(X, InteractionMatrix):
                     batch = X.users_in(users)
                 else:
-                    batch = lil_matrix(X.shape)
-                    batch[users] = X[users]
-                    batch = batch.tocsr()
+                    batch = csr_from_rows(X[users], users, X.shape)
 
-                results[users] = self._get_top_k_recommendations(self._batch_predict(batch, users=users)[users])
+                batch_users.extend(users)
+                batch_results.append(
+                    self._get_top_k_recommendations(csr_matrix(self._batch_predict(batch, users=users))[users])
+                )
+
+        if not batch_results:
+            return csr_matrix(X.shape)
+
+        # Assemble the batch results into the full-size prediction matrix
+        # in a single pass, instead of writing into a full-size lil_matrix
+        # once per batch.
+        results = csr_from_rows(vstack(batch_results, format="csr"), batch_users, X.shape)
 
         logger.debug(f"shape of response ({results.shape})")
 
-        return results.tocsr()
+        return results
 
     def _transform_fit_input(
         self, X: Matrix, validation_data: Tuple[Matrix, Matrix]

--- a/recpack/algorithms/bprmf.py
+++ b/recpack/algorithms/bprmf.py
@@ -20,7 +20,6 @@ import torch.optim as optim
 from recpack.algorithms.base import TorchMLAlgorithm
 from recpack.algorithms.loss_functions import bpr_loss
 from recpack.algorithms.samplers import BootstrapSampler
-from recpack.algorithms.util import csr_from_rows
 
 logger = logging.getLogger("recpack")
 
@@ -158,7 +157,9 @@ class BPRMF(TorchMLAlgorithm):
         :type X: csr_matrix
         :param users: users selected for recommendation
         :type users: List[int]
-        :return: Sparse matrix of scores per user item pair.
+        :return: Sparse matrix of scores per user item pair,
+            compact with shape (len(users), num_items):
+            row i corresponds to users[i].
         :rtype: csr_matrix
         """
 
@@ -167,7 +168,7 @@ class BPRMF(TorchMLAlgorithm):
 
         scores = self.model_(user_tensor, item_tensor).detach().cpu().numpy()
 
-        return csr_from_rows(csr_matrix(scores), users, X.shape)
+        return csr_matrix(scores)
 
     def _train_epoch(self, train_data: csr_matrix):
         """train a single epoch. Uses sampler to generate samples,

--- a/recpack/algorithms/bprmf.py
+++ b/recpack/algorithms/bprmf.py
@@ -8,7 +8,7 @@
 import logging
 from typing import List
 
-from scipy.sparse import csr_matrix, lil_matrix
+from scipy.sparse import csr_matrix
 
 from tqdm.auto import tqdm
 
@@ -20,6 +20,7 @@ import torch.optim as optim
 from recpack.algorithms.base import TorchMLAlgorithm
 from recpack.algorithms.loss_functions import bpr_loss
 from recpack.algorithms.samplers import BootstrapSampler
+from recpack.algorithms.util import csr_from_rows
 
 logger = logging.getLogger("recpack")
 
@@ -164,10 +165,9 @@ class BPRMF(TorchMLAlgorithm):
         user_tensor = torch.LongTensor(users).to(self.device)
         item_tensor = torch.arange(X.shape[1]).to(self.device)
 
-        result = lil_matrix(X.shape)
-        result[users] = self.model_(user_tensor, item_tensor).detach().cpu().numpy()
+        scores = self.model_(user_tensor, item_tensor).detach().cpu().numpy()
 
-        return result.tocsr()
+        return csr_from_rows(csr_matrix(scores), users, X.shape)
 
     def _train_epoch(self, train_data: csr_matrix):
         """train a single epoch. Uses sampler to generate samples,

--- a/recpack/algorithms/mult_vae.py
+++ b/recpack/algorithms/mult_vae.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from recpack.algorithms.base import TorchMLAlgorithm
 from recpack.algorithms.loss_functions import vae_loss
-from recpack.algorithms.util import csr_from_rows, naive_sparse2tensor, get_batches
+from recpack.algorithms.util import naive_sparse2tensor, get_batches
 
 logger = logging.getLogger("recpack")
 
@@ -234,7 +234,9 @@ class MultVAE(TorchMLAlgorithm):
         :type X: csr_matrix
         :param users: users selected for recommendation
         :type users: List[int]
-        :return: Sparse matrix of scores per user item pair.
+        :return: Sparse matrix of scores per user item pair,
+            compact with shape (len(users), num_items):
+            row i corresponds to users[i].
         :rtype: csr_matrix
         """
         active_users = X[users]
@@ -245,7 +247,7 @@ class MultVAE(TorchMLAlgorithm):
 
         scores = out_tensor.detach().cpu().numpy()
 
-        return csr_from_rows(csr_matrix(scores), users, X.shape)
+        return csr_matrix(scores)
 
 
 class MultiVAETorch(nn.Module):

--- a/recpack/algorithms/mult_vae.py
+++ b/recpack/algorithms/mult_vae.py
@@ -7,7 +7,6 @@
 
 import logging
 from typing import List, Tuple
-from scipy.sparse import lil_matrix
 
 import torch.nn as nn
 import torch.nn.functional as F
@@ -18,7 +17,7 @@ import numpy as np
 
 from recpack.algorithms.base import TorchMLAlgorithm
 from recpack.algorithms.loss_functions import vae_loss
-from recpack.algorithms.util import naive_sparse2tensor, get_batches
+from recpack.algorithms.util import csr_from_rows, naive_sparse2tensor, get_batches
 
 logger = logging.getLogger("recpack")
 
@@ -244,10 +243,9 @@ class MultVAE(TorchMLAlgorithm):
 
         out_tensor, _, _ = self.model_(in_tensor)
 
-        result = lil_matrix(X.shape)
-        result[users] = out_tensor.detach().cpu().numpy()
+        scores = out_tensor.detach().cpu().numpy()
 
-        return result.tocsr()
+        return csr_from_rows(csr_matrix(scores), users, X.shape)
 
 
 class MultiVAETorch(nn.Module):

--- a/recpack/algorithms/p2v.py
+++ b/recpack/algorithms/p2v.py
@@ -249,11 +249,13 @@ class Prod2Vec(TorchMLAlgorithm):
         :type X: csr_matrix
         :param users: users selected for recommendation
         :type users: List[int]
-        :return: Sparse matrix of scores per user item pair.
+        :return: Sparse matrix of scores per user item pair,
+            compact with shape (len(users), num_items):
+            row i corresponds to users[i].
         :rtype: csr_matrix
         """
         scores = X @ self.similarity_matrix_
-        return scores
+        return scores[users]
 
     def _skipgram_sample_pairs(
         self, X: InteractionMatrix

--- a/recpack/algorithms/rec_vae.py
+++ b/recpack/algorithms/rec_vae.py
@@ -17,7 +17,7 @@ import torch
 import torch.optim as optim
 
 from recpack.algorithms.base import TorchMLAlgorithm
-from recpack.algorithms.util import csr_from_rows, swish, log_norm_pdf, naive_sparse2tensor, get_batches
+from recpack.algorithms.util import swish, log_norm_pdf, naive_sparse2tensor, get_batches
 
 
 logger = logging.getLogger("recpack")
@@ -278,7 +278,9 @@ class RecVAE(TorchMLAlgorithm):
         :type X: csr_matrix
         :param users: users selected for recommendation
         :type users: List[int]
-        :return: Sparse matrix of scores per user item pair.
+        :return: Sparse matrix of scores per user item pair,
+            compact with shape (len(users), num_items):
+            row i corresponds to users[i].
         :rtype: csr_matrix
         """
         active_users = X[users]
@@ -289,7 +291,7 @@ class RecVAE(TorchMLAlgorithm):
 
         scores = out_tensor.detach().cpu().numpy()
 
-        return csr_from_rows(csr_matrix(scores), users, X.shape)
+        return csr_matrix(scores)
 
 
 class CompositePrior(nn.Module):

--- a/recpack/algorithms/rec_vae.py
+++ b/recpack/algorithms/rec_vae.py
@@ -10,14 +10,14 @@ import logging
 from typing import List, Tuple, Optional
 
 import numpy as np
-from scipy.sparse import csr_matrix, lil_matrix
+from scipy.sparse import csr_matrix
 import torch.nn as nn
 import torch.nn.functional as F
 import torch
 import torch.optim as optim
 
 from recpack.algorithms.base import TorchMLAlgorithm
-from recpack.algorithms.util import swish, log_norm_pdf, naive_sparse2tensor, get_batches
+from recpack.algorithms.util import csr_from_rows, swish, log_norm_pdf, naive_sparse2tensor, get_batches
 
 
 logger = logging.getLogger("recpack")
@@ -287,10 +287,9 @@ class RecVAE(TorchMLAlgorithm):
 
         out_tensor, _, _ = self.model_(in_tensor)
 
-        result = lil_matrix(X.shape)
-        result[users] = out_tensor.detach().cpu().numpy()
+        scores = out_tensor.detach().cpu().numpy()
 
-        return result.tocsr()
+        return csr_from_rows(csr_matrix(scores), users, X.shape)
 
 
 class CompositePrior(nn.Module):

--- a/recpack/algorithms/stan.py
+++ b/recpack/algorithms/stan.py
@@ -250,7 +250,7 @@ class STAN(Algorithm):
             # so wether it is 1 or 0 does not impact the reproduction results.
             # Because recpack does not always remove history items,
             # it makes more sense to not recommend this last matching item as well.
-            item_weights = neighborhood_positions - (neighborhood_positions > 0).multiply(last_match.A)
+            item_weights = neighborhood_positions - (neighborhood_positions > 0).multiply(last_match.toarray())
 
             item_weights.data = np.exp(-np.abs(item_weights.data) * self.distance_from_match_decay)
 

--- a/recpack/algorithms/util.py
+++ b/recpack/algorithms/util.py
@@ -50,6 +50,43 @@ def get_users(data: Matrix) -> List[int]:
     return list(set(data.nonzero()[0]))
 
 
+def csr_from_rows(rows: csr_matrix, row_indices: Union[List[int], np.ndarray], shape: tuple) -> csr_matrix:
+    """Place a block of rows into an otherwise empty csr_matrix of the given shape.
+
+    Row ``i`` of ``rows`` becomes row ``row_indices[i]`` of the result.
+    The result is constructed directly from the CSR internals
+    (data, indices and a recomputed indptr), which is much faster than
+    allocating a full-size lil_matrix and assigning rows into it.
+
+    :param rows: Matrix with the rows to place, shape (len(row_indices), shape[1]).
+    :type rows: csr_matrix
+    :param row_indices: For every row in ``rows``, the row index it should get
+        in the output matrix. Indices may be in any order, but must be unique.
+    :type row_indices: Union[List[int], np.ndarray]
+    :param shape: Shape of the output matrix.
+    :type shape: tuple
+    :return: Matrix of the requested shape, with the given rows filled in
+        and every other row empty.
+    :rtype: csr_matrix
+    """
+    row_indices = np.asarray(row_indices)
+
+    # The data arrays can only be reused directly
+    # if they are ordered by output row.
+    order = np.argsort(row_indices)
+    if not np.array_equal(order, np.arange(len(row_indices))):
+        rows = rows[order]
+        row_indices = row_indices[order]
+
+    row_counts = np.zeros(shape[0], dtype=rows.indptr.dtype)
+    row_counts[row_indices] = np.diff(rows.indptr)
+
+    indptr = np.zeros(shape[0] + 1, dtype=rows.indptr.dtype)
+    np.cumsum(row_counts, out=indptr[1:])
+
+    return csr_matrix((rows.data, rows.indices, indptr), shape=shape)
+
+
 def get_batches(iterable: Iterable, batch_size=1000) -> Iterator[List]:
     """Get batches from an iterable.
 
@@ -93,8 +130,7 @@ def sample_rows(*args: Matrix, sample_size: int = 1000) -> List[Matrix]:
         if type(mat) == InteractionMatrix:
             sampled_mat = mat.users_in(users)
         else:
-            sampled_mat = csr_matrix(mat.shape)
-            sampled_mat[users, :] = mat[users, :]
+            sampled_mat = csr_from_rows(mat[users, :], users, mat.shape)
 
         sampled_matrices.append(sampled_mat)
 

--- a/recpack/tests/test_algorithms/test_algorithms_base.py
+++ b/recpack/tests/test_algorithms/test_algorithms_base.py
@@ -165,5 +165,13 @@ def test_sampled_validation(algo_class, larger_mat):
 
     for c in mock.update.call_args_list:
         val_out, X_pred = c.args
-        assert len(set(val_out.nonzero()[0])) == N_SAMPLES
-        assert len(set(X_pred.nonzero()[0])) == N_SAMPLES
+        sampled_users = set(val_out.nonzero()[0])
+        assert len(sampled_users) == N_SAMPLES
+
+        # Predictions are made for the sampled users only.
+        # Not every algorithm can guarantee a recommendation for every user
+        # (e.g. Prod2VecClustered only recommends items from neighbouring
+        # clusters), so the predicted users are a subset of the sample.
+        predicted_users = set(X_pred.nonzero()[0])
+        assert predicted_users
+        assert predicted_users <= sampled_users

--- a/recpack/tests/test_algorithms/test_algorithms_util.py
+++ b/recpack/tests/test_algorithms/test_algorithms_util.py
@@ -10,6 +10,7 @@ from scipy.sparse import csr_matrix
 from torch import Tensor
 
 from recpack.algorithms.util import (
+    csr_from_rows,
     get_batches,
     invert,
     naive_sparse2tensor,
@@ -132,3 +133,61 @@ def test_invert():
     inv = invert(a)
 
     np.testing.assert_almost_equal(inv, expected)
+
+
+def test_csr_from_rows():
+    rows = csr_matrix(np.array([[1, 0, 2], [0, 3, 0]]))
+
+    result = csr_from_rows(rows, [4, 1], (6, 3))
+
+    expected = np.zeros((6, 3))
+    expected[4] = [1, 0, 2]
+    expected[1] = [0, 3, 0]
+
+    assert isinstance(result, csr_matrix)
+    np.testing.assert_array_equal(result.toarray(), expected)
+
+
+def test_csr_from_rows_sorted_indices():
+    rows = csr_matrix(np.array([[1, 0, 2], [0, 3, 0]]))
+
+    result = csr_from_rows(rows, [1, 4], (6, 3))
+
+    expected = np.zeros((6, 3))
+    expected[1] = [1, 0, 2]
+    expected[4] = [0, 3, 0]
+
+    np.testing.assert_array_equal(result.toarray(), expected)
+
+
+def test_csr_from_rows_matches_lil_construction():
+    # The utility replaces the lil_matrix allocate-and-assign pattern:
+    # results must be identical for arbitrary inputs.
+    from scipy.sparse import lil_matrix, random as sparse_random
+
+    rng = np.random.default_rng(42)
+    for _ in range(5):
+        num_rows, num_cols = 50, 20
+        selected = rng.choice(num_rows, size=10, replace=False)
+
+        rows = csr_matrix(sparse_random(len(selected), num_cols, density=0.3, random_state=rng))
+
+        reference = lil_matrix((num_rows, num_cols))
+        reference[selected] = rows
+        reference = reference.tocsr()
+
+        result = csr_from_rows(rows, selected, (num_rows, num_cols))
+
+        np.testing.assert_array_almost_equal(result.toarray(), reference.toarray())
+
+
+def test_csr_from_rows_empty_rows():
+    # Rows without any values should be handled correctly.
+    rows = csr_matrix(np.array([[0, 0, 0], [1, 0, 0]]))
+
+    result = csr_from_rows(rows, [2, 0], (4, 3))
+
+    expected = np.zeros((4, 3))
+    expected[0] = [1, 0, 0]
+
+    np.testing.assert_array_equal(result.toarray(), expected)

--- a/recpack/tests/test_algorithms/test_bprmf.py
+++ b/recpack/tests/test_algorithms/test_bprmf.py
@@ -136,6 +136,31 @@ def test_forward(X_in_for_pairwise):
     assert res_2 == res_1[1, 1]
 
 
+def test_bprmf_predict_multi_batch_row_placement(X_in_for_pairwise):
+    """Predictions must land on the correct row even when users are split
+    across multiple, differently-ordered batches.
+
+    This guards against a regression in the row-reassembly logic that
+    replaced the old per-batch lil_matrix allocation (see
+    recpack.algorithms.util.csr_from_rows): a bug there would silently
+    shuffle or overwrite rows between batches, rather than raising.
+    """
+    a = BPRMF(num_components=4, max_epochs=1, batch_size=1, seed=42)
+    a.fit(X_in_for_pairwise, (X_in_for_pairwise, X_in_for_pairwise))
+
+    # batch_size=2 forces get_users' unordered set to be split into several
+    # batches, none of which is processed in row-index order.
+    a.batch_size = 2
+    X_pred = a.predict(X_in_for_pairwise)
+
+    users = sorted(set(X_in_for_pairwise.nonzero()[0]))
+    item_tensor = torch.arange(X_in_for_pairwise.shape[1])
+
+    for user in users:
+        expected = a.model_.forward(torch.LongTensor([user]), item_tensor).detach().numpy().flatten()
+        np.testing.assert_array_almost_equal(X_pred[user].toarray().flatten(), expected)
+
+
 def test_bad_stopping_criterion(X_in):
     with pytest.raises(ValueError):
         BPRMF(stopping_criterion="not_a_correct_value")

--- a/recpack/tests/test_algorithms/test_p2v.py
+++ b/recpack/tests/test_algorithms/test_p2v.py
@@ -184,8 +184,15 @@ def test_batch_predict(prod2vec):
     matrix[[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]] = 1
 
     prod2vec._create_similarity_matrix(InteractionMatrix.from_csr_matrix(matrix))
-    predictions = prod2vec._batch_predict(matrix, get_users(matrix))
+    users = get_users(matrix)
+    predictions = prod2vec._batch_predict(matrix, users)
 
+    # _batch_predict returns a compact matrix: row i corresponds to
+    # users[i], not to global user id i. User 5 has no interactions and
+    # is not in `users`, so it has no row in the output (it previously
+    # got an all-zero row, back when _batch_predict returned a full
+    # X.shape matrix).
+    assert users == [0, 1, 2, 3, 4]
     np.testing.assert_array_almost_equal(
         predictions.toarray(),
         np.array(
@@ -195,7 +202,6 @@ def test_batch_predict(prod2vec):
                 [0.0, 0.0, 0.0, 0.5, 0.0],
                 [0.0, 0.12309149, 0.5, 0.0, 0.0],
                 [0.70710678, 0.69631062, 0.0, 0.0, 0.0],
-                [0.0, 0.0, 0.0, 0.0, 0.0],
             ]
         ),
     )

--- a/recpack/tests/test_algorithms/test_p2v_clustered.py
+++ b/recpack/tests/test_algorithms/test_p2v_clustered.py
@@ -54,9 +54,12 @@ def test__predict(prod2vec, larger_mat):
     matrix[[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]] = 1
 
     prod2vec._create_similarity_matrix(larger_mat)
-    predictions = prod2vec._batch_predict(matrix, get_users(matrix))
+    users = get_users(matrix)
+    predictions = prod2vec._batch_predict(matrix, users)
 
-    assert predictions.shape == matrix.shape
+    # _batch_predict returns a compact matrix, one row per user in `users`,
+    # not a full matrix.shape matrix.
+    assert predictions.shape == (len(users), matrix.shape[1])
 
 
 def test_cluster_similarity_computation():

--- a/recpack/tests/test_algorithms/test_stan.py
+++ b/recpack/tests/test_algorithms/test_stan.py
@@ -61,7 +61,7 @@ def test_fit(algo, mini_training_dataset):
     )
 
     expected_session_timestamps = [[3, 2, 0, 0]]
-    np.testing.assert_array_equal(algo.historical_session_timestamps_.A.T, expected_session_timestamps)
+    np.testing.assert_array_equal(algo.historical_session_timestamps_.toarray().T, expected_session_timestamps)
 
 
 def test_compute_session_similarity(algo, mini_training_dataset, mini_test_dataset):

--- a/recpack/util.py
+++ b/recpack/util.py
@@ -64,8 +64,23 @@ def get_top_K_ranks(X: csr_matrix, K: Optional[int] = None) -> csr_matrix:
         K_row_pick = min(K, ri - le) if K is not None else ri - le
 
         if K_row_pick != 0:
+            row_cols = X.indices[le:ri]
+            row_data = X.data[le:ri]
 
-            top_k_row = X.indices[le + np.argpartition(X.data[le:ri], list(range(-K_row_pick, 0)))[-K_row_pick:]]
+            if K_row_pick < ri - le:
+                # Preselect the K largest values, plus any ties at the boundary,
+                # so the tie-break below sees all tied candidates.
+                partitioned = np.argpartition(row_data, -K_row_pick)
+                cutoff = row_data[partitioned[-K_row_pick]]
+                candidates = row_data >= cutoff
+                row_cols = row_cols[candidates]
+                row_data = row_data[candidates]
+
+            # Sort ascending by value, with the column index as tie-breaker,
+            # so a tie for the last position resolves to the largest index,
+            # independent of the matrix' internal storage order.
+            order = np.lexsort((row_cols, row_data))
+            top_k_row = row_cols[order[-K_row_pick:]]
 
             for rank, col_ix in enumerate(reversed(top_k_row)):
                 U.append(row_ix)


### PR DESCRIPTION
## Description

Fixes a performance bottleneck in `TorchMLAlgorithm`'s batch prediction
path: `validation_sample_size` lets you validate on a small sample of
users instead of the full dataset, but every stage of the prediction
pipeline still allocated matrices at the *full* dataset shape, so the
sampling optimisation delivered little to no speed-up in practice.

The root cause is a repeated pattern:

```python
sampled_mat = csr_matrix(mat.shape)       # full dataset size
sampled_mat[users, :] = mat[users, :]     # only a few rows written